### PR TITLE
Fix subrecord arrays

### DIFF
--- a/Fallout3/Records/CELL.md
+++ b/Fallout3/Records/CELL.md
@@ -12,11 +12,11 @@ Count | Subrecord | Name | Type | Info
 + | DATA | Flags | uint8 | See below for values.
  | XCLC | Grid | struct |
  | XCLL | Lighting | struct |
--* | IMPF | Footstep Material | byte[30] | The format of each IMPF subrecord is unknown. There can be up to 10 IMPF subrecords, corresponding to different materials. The mapping is given below.
+ | [IMPF](Subrecords/IMPF.md) | Footstep Material | struct |
 + | | Light Template | collection | See below for details.
  | XCLW | Water Height | float32
  | XNAM | Water Noise Texture | cstring |
-*- | XCLR | Region | formid | FormID of a [REGN](REGN.md) record.
+ | XCLR | Regions | formid[] | Array of [REGN](REGN.md) record FormIDs.
  | XCIM | Image Space | formid | FormID of an [IMGS](IMGS.md) record.
  | XCET | Unknown | byte |
  | XEZN | Encounter Zone | formid | FormID of an [ECZN](ECZN.md) record.
@@ -41,22 +41,6 @@ Value | Meaning
 0x20 | Public Place
 0x40 | Hand Changed
 0x80 | Behave Like Exterior
-
-### IMPF Map
-
-IMPF Subrecord | Footstep Material
------------|------------------
-1st | ConcSolid
-2nd | ConcBroken
-3rd | MetalSolid
-4th | MetalHollow
-5th | MetalSheet
-6th | Wood
-7th | Sand
-8th | Dirt
-9th | Grass
-10th | Water
-
 
 ### XCLC
 
@@ -110,4 +94,3 @@ Value | Meaning
 0x00000040 | Directional Fade
 0x00000080 | Fog Clip Distance
 0x00000100 | Fog Power
-

--- a/Fallout3/Records/CLMT.md
+++ b/Fallout3/Records/CLMT.md
@@ -8,7 +8,7 @@ Climate
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
 + | EDID | Editor ID | cstring |
--* | WLST | Weather Type | struct | 
+ | WLST | Weather Types | struct |
  | FNAM | Sun Texture | cstring |
  | GNAM | Sun Glare Texture | cstring |
 - | | [Model Data](Subrecords/Model.md) | collection |
@@ -17,21 +17,21 @@ Count | Subrecord | Name | Type | Info
 
 ### WLST
 
+The WLST subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 Weather | formid | FormID of a [WTHR](WTHR.md) record, or null.
-Chance | int32 | 
+Chance | int32 |
 Global | formid | FormID of a [GLOB](GLOB.md) record, or null.
 
 ### TNAM
 
 Name | Type | Info
 -----|------|-----
-Sunrise Begin | uint8 | 
+Sunrise Begin | uint8 |
 Sunrise End | uint8 |
 Sunset Begin | uint8 |
 Sunset End | uint8 |
 Volatility | uint8 |
 Moons / Phase Length | uint8 |
- 
-

--- a/Fallout3/Records/CPTH.md
+++ b/Fallout3/Records/CPTH.md
@@ -9,9 +9,16 @@ Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
 + | EDID | Editor ID | cstring |
 -* | [CTDA](Subrecords/CTDA.md) | Condition | struct |
-+* | ANAM | Related Camera Path | formid | FormID of a [CPTH](CPTH.md) record, or null. The first ANAM subrecord maps to the parent, the second maps to the previous sibling.
+ | ANAM | Related Camera Paths | struct |
 + | DATA | Camera Zoom | uint8 | Enum - see below for values.
 -* | SNAM | Camera Shot | formid | FormID of a [CAMS](CAMS.md) record.
+
+### ANAM
+
+Name | Type | Info
+-----|------|-----
+Parent Camera Path | formid | FormID of a [CPTH](CPTH.md) record, or null.
+Previous Sibling Camera Path | formid | FormID of a [CPTH](CPTH.md) record, or null.
 
 ### DATA Enum Values
 

--- a/Fallout3/Records/CREA.md
+++ b/Fallout3/Records/CREA.md
@@ -14,7 +14,7 @@ Count | Subrecord | Name | Type | Info
 -* | SPLO | Actor Effect | formid | FormID of a [SPEL](SPEL.md) record.
  | EITM | Unarmed Attack Effect | formid | FormID of a [ENCH](ENCH.md) or [SPEL](SPEL.md) record.
 + | [EAMT](Values/Attack Animations.md) | Unarmed Attack Animation | uint16 |
--* | NIFZ | Model | cstring |
+- | NIFZ | Model List | cstring[] | An array of models.
  | NIFT | Texture File Hashes | uint8[] |
 + | [ACBS](Subrecords/ACBS.md) | Configuration | struct |
 -* | [SNAM](Subrecords/SNAM (CREA, NPC_).md) | Faction | struct |
@@ -26,7 +26,7 @@ Count | Subrecord | Name | Type | Info
 -* | | [Item](Subrecords/Item.md) | collection |
  | [AIDT](Subrecords/AIDT.md) | AI Data | struct |
 -* | PKID | Package | formid | FormID of a [PACK](PACK.md) record.
--* | KFFZ | Animation | cstring |
+- | KFFZ | Animations | cstring[] | An array of animations.
 + | DATA | Data | struct |
 + | RNAM | Attack Reach | uint8 |
  | ZNAM | Combat Style | formid | FormID of a [CSTY](CSTY.md) record.
@@ -99,4 +99,3 @@ Value | Meaning
 9 | Weapon
 10 | Movement
 11 | Conscious
-

--- a/Fallout3/Records/DOBJ.md
+++ b/Fallout3/Records/DOBJ.md
@@ -8,30 +8,30 @@ Default Object Manager
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
 + | EDID | Editor ID | cstring |
-+* | DATA | Default Object | formid | Each DATA subrecord is mapped to a different type of object. The mapping is given below.
++ | DATA | Default Objects | struct |
 
-### DATA Mapping
+### DATA
 
-DATA Subrecord Index | Object Type
------------------|------------
-0 | Stimpack
-1 | SuperStimpack
-2 | RadX
-3 | RadAway
-4 | Morphine
-5 | Perk Paralysis
-6 | Player Faction
-7 | Mysterious Stranger NPC
-8 | Mysterious Stranger Faction
-9 | Default Music
-10 | Battle Music
-11 | Death Music
-12 | Success Music
-13 | Level Up Music
-14 | Player Voice (Male)
-15 | Player Voice (Male Child)
-16 | Player Voice (Female)
-17 | Player Voice (Female Child)
-18 | Eat Package Default Food
-19 | Every Actor Ability
-20 | Drug Wears Off Image Space
+Name | Type | Info
+-----|------|-----
+Stimpack | formid |
+SuperStimpack | formid |
+RadX | formid |
+RadAway | formid |
+Morphine | formid |
+Perk Paralysis | formid |
+Player Faction | formid |
+Mysterious Stranger NPC | formid |
+Mysterious Stranger Faction | formid |
+Default Music | formid |
+Battle Music | formid |
+Death Music | formid |
+Success Music | formid |
+Level Up Music | formid |
+Player Voice (Male) | formid |
+Player Voice (Male Child) | formid |
+Player Voice (Female) | formid |
+Player Voice (Female Child) | formid |
+Eat Package Default Food | formid |
+Every Actor Ability | formid |
+Drug Wears Off Image Space | formid |

--- a/Fallout3/Records/IDLE.md
+++ b/Fallout3/Records/IDLE.md
@@ -10,8 +10,15 @@ Count | Subrecord | Name | Type | Info
  | EDID | Editor ID | cstring |
 + | | [Model Data](Subrecords/Model.md) | collection |
 -* | [CTDA](Subrecords/CTDA.md) | Condition | struct |
-+* | ANAM | Related Idle Animation | formid | FormID of an [IDLE](IDLE.md) record, or null. The first ANAM subrecord is for the parent, the second for the previous sibling.
+ | ANAM | Related Idle Animations | struct |
 + | DATA | | struct |
+
+### ANAM
+
+Name | Type | Info
+-----|------|-----
+Parent Idle Animation | formid | FormID of a [IDLE](IDLE.md) record, or null.
+Previous Sibling Idle Animation | formid | FormID of a [IDLE](IDLE.md) record, or null.
 
 ### DATA
 
@@ -24,7 +31,7 @@ Unused | byte |
 Replay Delay | int16 |
 Flags | uint8 | See below for values.
 Unused | byte |
- 
+
 #### Animation Group Section Values
 
 Value | Animation Group

--- a/Fallout3/Records/IDLM.md
+++ b/Fallout3/Records/IDLM.md
@@ -10,9 +10,9 @@ Count | Subrecord | Name | Type | Info
 + | EDID | Editor ID | cstring |
 + | [OBND](Subrecords/OBND.md) | Object Bounds | struct |
 + | IDLF | Flags | uint8 | See below for values.
-+ | IDLC | | struct | 
++ | IDLC | | struct |
 + | IDLT | Idle Timer Setting | float32 |
-+* | IDLA | Animation | formid | FormID of a [IDLE](IDLE.md) record, or null.
+ | [IDLA](Subrecords/IDLA.md) | Animations | struct |
 
 ### IDLF Flag Values
 
@@ -28,4 +28,3 @@ Name | Type | Info
 -----|------|-----
 Animation Count | uint8 |
 Unused | byte[3] |
- 

--- a/Fallout3/Records/IMAD.md
+++ b/Fallout3/Records/IMAD.md
@@ -1,45 +1,45 @@
 IMAD
 ====
 
-Image Space Modifier
+Image Space Adapter
 
 ## Format
 
-Some of the subrecord codes begin with unprintable or whitespace characters. Such characters are given below using their hex values. Eg. `IIAD` would be `0x49 IAD` below if `I` were unprintable.
+Some of the subrecord codes begin with unprintable or whitespace characters. Such characters are given below using their hex values. Eg. `IIAD` would be `0x49 IAD` below if `I` were unprintable. The Time and Color structures used by many of the subrecords are detailed below.
 
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | EDID | Editor ID | cstring |
- | DNAM | Unknown | ?? |
- | BNAM | Unknown | ?? |
- | VNAM | Unknown | ?? |
- | TNAM | Unknown | ?? |
- | NAM3 | Unknown | ?? |
- | RNAM | Unknown | ?? |
- | SNAM | Unknown | ?? |
- | UNAM | Unknown | ?? |
- | NAM1 | Unknown | ?? |
- | NAM2 | Unknown | ?? |
- | WNAM | Unknown | ?? |
- | XNAM | Unknown | ?? |
- | YNAM | Unknown | ?? |
- | NAM4 | Unknown | ?? |
- | 0x00 IAD | Unknown | ?? |
- | @IAD | Unknown | ?? |
- | 0x01 IAD | Unknown | ?? |
- | AIAD | Unknown | ?? |
- | 0x02 IAD | Unknown | ?? |
- | BIAD | Unknown | ?? |
- | 0x03 IAD | Unknown | ?? |
- | CIAD | Unknown | ?? |
- | 0x04 IAD | Unknown | ?? |
- | DIAD | Unknown | ?? |
- | 0x05 IAD | Unknown | ?? |
- | EIAD | Unknown | ?? |
- | 0x06 IAD | Unknown | ?? |
- | FIAD | Unknown | ?? |
- | 0x07 IAD | Unknown | ?? |
- | GIAD | Unknown | ?? |
+ | DNAM | Data Count | struct |
+ | BNAM | Blur Radius | struct[] | An array of Time structures.
+ | VNAM | Double Vision Strength | struct[] | An array of Time structures.
+ | TNAM | Tint Color | struct[] | An array of Color structures.
+ | NAM3 | Fade Color | struct[] | An array of Color structures.
+ | RNAM | Radial Blur Strength | struct[] | An array of Time structures.
+ | SNAM | Radial Blur Ramp Up | struct[] | An array of Time structures.
+ | UNAM | Radial Blur Start | struct[] | An array of Time structures.
+ | NAM1 | Radial Blur Ramp Down | struct[] | An array of Time structures.
+ | NAM2 | Radial Blur Down Start | struct[] | An array of Time structures.
+ | WNAM | DoF Strength | struct[] | An array of Time structures.
+ | XNAM | DoF Distance | struct[] | An array of Time structures.
+ | YNAM | DoF Range | struct[] | An array of Time structures.
+ | NAM4 | Motion Blur Strength | struct[] | An array of Time structures.
+ | 0x00 IAD | HDR Eye Adapt Speed Mult | struct[] | An array of Time structures.
+ | @IAD | HDR Eye Adapt Speed Add | struct[] | An array of Time structures.
+ | 0x01 IAD | HDR Bloom Blur Radius Mult | struct[] | An array of Time structures.
+ | AIAD | HDR Bloom Blur Radius Add | struct[] | An array of Time structures.
+ | 0x02 IAD | HDR Bloom Threshold Mult | struct[] | An array of Time structures.
+ | BIAD | HDR Bloom Threshold Add | struct[] | An array of Time structures.
+ | 0x03 IAD | HDR Bloom Scale Mult | struct[] | An array of Time structures.
+ | CIAD | HDR Bloom Scale Add | struct[] | An array of Time structures.
+ | 0x04 IAD | HDR Target Lum Min Mult | struct[] | An array of Time structures.
+ | DIAD | HDR Target Lum Min Add | struct[] | An array of Time structures.
+ | 0x05 IAD | HDR Target Lum Max Mult | struct[] | An array of Time structures.
+ | EIAD | HDR Target Lum Max Add | struct[] | An array of Time structures.
+ | 0x06 IAD | HDR Sunlight Scale Mult | struct[] | An array of Time structures.
+ | FIAD | HDR Sunlight Scale Add | struct[] | An array of Time structures.
+ | 0x07 IAD | HDR Sky Scale Mult | struct[] | An array of Time structures.
+ | GIAD | HDR Sky Scale Add | struct[] | An array of Time structures.
  | 0x08 IAD | Unknown | ?? |
  | HIAD | Unknown | ?? |
  | 0x09 IAD | Unknown | ?? |
@@ -58,12 +58,97 @@ Count | Subrecord | Name | Type | Info
  | OIAD | Unknown | ?? |
  | 0x10 IAD | Unknown | ?? |
  | PIAD | Unknown | ?? |
- | 0x11 IAD | Unknown | ?? |
- | QIAD | Unknown | ?? |
- | 0x12 IAD | Unknown | ?? |
- | RIAD | Unknown | ?? |
- | 0x13 IAD | Unknown | ?? |
- | SIAD | Unknown | ?? |
+ | 0x11 IAD | Cinematic Saturation Mult | struct[] | An array of Time structures.
+ | QIAD | Cinematic Saturation Add | struct[] | An array of Time structures.
+ | 0x12 IAD | Cinematic Brightness Mult | struct[] | An array of Time structures.
+ | RIAD | Cinematic Brightness Add | struct[] | An array of Time structures.
+ | 0x13 IAD | Cinematic Contrast Mult | struct[] | An array of Time structures.
+ | SIAD | Cinematic Contrast Add | struct[] | An array of Time structures.
  | 0x14 IAD | Unknown | ?? |
  | TIAD | Unknown | ?? |
+ | RDSD | Sound - Intro | formid | FormID of a [SOUN](SOUN.md) record.
+ | RDSI | Sound - Outro | formid | FormID of a [SOUN](SOUN.md) record.
 
+
+### DNAM
+
+Name | Type | Info
+-----|------|-----
+Flags | uint32 | See below for flag values.
+Duration | float32 |
+HDR Eye Adapt Speed Mult | uint32 |
+HDR Eye Adapt Speed Add | uint32 |
+HDR Bloom Blur Radius Mult | uint32 |
+HDR Bloom Blur Radius Add | uint32 |
+HDR Bloom Threshold Mult | uint32 |
+HDR Bloom Threshold Add | uint32 |
+HDR Bloom Scale Mult | uint32 |
+HDR Bloom Scale Add | uint32 |
+HDR Target Lum Min Mult | uint32 |
+HDR Target Lum Min Add | uint32 |
+HDR Target Lum Max Mult | uint32 |
+HDR Target Lum Max Add | uint32 |
+HDR Sunlight Scale Mult | uint32 |
+HDR Sunlight Scale Add | uint32 |
+HDR Sky Scale Mult | uint32 |
+HDR Sky Scale Add | uint32 |
+Unknown | uint8[72] |
+Cinematic Saturation Mult | uint32 |
+Cinematic Saturation Add | uint32 |
+Cinematic Brightness Mult | uint32 |
+Cinematic Brightness Add | uint32 |
+Cinematic Contrast Mult | uint32 |
+Cinematic Contrast Add | uint32 |
+Unknown | uint8[8] |
+Tint Color | uint32 |
+Blur Radius | uint32 |
+Double Vision Strength | uint32 |
+Radial Blur Strength | uint32 |
+Radial Blur Ramp Up | uint32 |
+Radial Blur Start | uint32 |
+Radial Blur Flags | uint32 | See below for flag values.
+Radial Blur Center X | uint32 |
+Radial Blur Center Y | uint32 |
+Depth of Field Strength | uint32 |
+Depth of Field Distance | uint32 |
+Depth of Field Range | uint32 |
+Depth of Field Flags | uint32 | See below for flag values.
+Radial Blur Ramp Down | uint32 |
+Radial Blur Down Start | uint32 |
+Fade Color | uint32 |
+Motion Blur Strength | uint32 |
+
+#### Flag Values
+
+Value | Meaning
+------|--------
+0x00000001 | Animatable
+
+#### Radial Blur Flag Values
+
+Value | Meaning
+------|--------
+0x00000001 | Use Target
+
+#### Depth of Field Flag Values
+
+Value | Meaning
+------|--------
+0x00000001 | Use Target
+
+### Time Structure
+
+Name | Type | Info
+-----|------|-----
+Time | float32 |
+Value | float32 |
+
+### Color Structure
+
+Name | Type | Info
+-----|------|-----
+Time | float32 |
+Red | float32 |
+Green | float32 |
+Blue | float32 |
+Alpha | float32 |

--- a/Fallout3/Records/LAND.md
+++ b/Fallout3/Records/LAND.md
@@ -8,15 +8,15 @@ Landscape
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | DATA | Unknown | uint8[] |
--* | VNML | Vertex Normal | struct | There are 33 VNML structs.
+ | VNML | Vertex Normal | struct |
  | VHGT | Vertex Height Map | struct |
--* | VCLR | Vertex Color |
+ | VCLR | Vertex Color | struct |
 -* | | Layer Subrecord Collection | collection | See below for details.
--* | VTEX | Texture | formid | FormID of an [LTEX](LTEX.md) record, or null.
+ | VTEX | Textures | formid[] | An array of [LTEX](LTEX.md) record FormIDs, or null.
 
 ### VNML / VCLR
 
-Each VNML / VCLR structure contains 33 repeats of the following structure, so that the array of VNML / VCLR structs forms a 33x33 grid where each VNML / VCLR is a row, and each instance of the structure below is a column.
+Each VNML / VCLR structure contains 1089 repeats of the following structure. The 1089 repeats are divided into 33 rows, and subdivided into 33 columns, forming a 33x33 grid.
 
 Name | Type | Info
 -----|------|-----
@@ -65,13 +65,14 @@ Value | Meaning
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | ATXT | Alpha Layer Header | struct |
--* | VTXT | Alpha Layer Cell Data | struct |
+ | VTXT | Alpha Layer Cell Data | struct |
 
 ##### VTXT
+
+The VTXT subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----
 Position | uint16 |
 Unused | byte[2] |
 Opacity | float32 |
-

--- a/Fallout3/Records/NAVM.md
+++ b/Fallout3/Records/NAVM.md
@@ -10,12 +10,12 @@ Count | Subrecord | Name | Type | Info
  | EDID | Editor ID | cstring |
  | NVER | Version | uint32 |
  | DATA | Data | struct |
--* | NVVX | Vertex | struct |
--* | NVTR | Triangle | struct |
--* | NVCA | Unknown | int16 |
--* | NVDP | Door | struct |
+ | NVVX | Vertices | struct |
+ | NVTR | Triangles | struct |
+ | NVCA | Unknown | int16[] | Unknown, may be triangle IDs.
+ | NVDP | Doors | struct |
  | NVGD | Unknown | uint8[] |
--* | NVEX | External Connection | struct |
+ | NVEX | External Connections | struct |
 
 ### DATA
 
@@ -30,6 +30,8 @@ Doors Count | uint32 |
 
 ### NVVX
 
+The NVVX subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 X | float32 |
@@ -37,6 +39,8 @@ Y | float32 |
 Z | float32 |
 
 ### NVTR
+
+The NVTR subrecord consists of an array of objects with the following structure.
 
 Count | Name | Type | Info
 ------|------|------|-----
@@ -87,6 +91,8 @@ Value | Meaning
 
 ### NVDP
 
+The NVDP subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 Reference | formid | FormID of a [REFR](REFR.md) record.
@@ -94,6 +100,8 @@ Unknown | uint16 |
 Unused | byte[2] |
 
 ### NVEX
+
+The NVEX subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----

--- a/Fallout3/Records/PACK.md
+++ b/Fallout3/Records/PACK.md
@@ -16,7 +16,7 @@ Count | Subrecord | Name | Type | Info
 + | IDLF | Idle Animation Flags | uint8 | See below for values.
 + | IDLC | Idle Animation Count | struct |
 + | IDLT | Idle Timer Setting | float32 |
-+* | IDLA | Idle Animations | formid | FormID of an [IDLE](IDLE.md) record.
+ | [IDLA](Subrecords/IDLA.md) | Animations | struct |
  | IDLB | Unused | byte[4] |
  | CNAM | Combat Style | formid | FormID of a [CSTY](CSTY.md) record.
  | PKED | Eat Marker | null |
@@ -31,17 +31,17 @@ Count | Subrecord | Name | Type | Info
  | PLD2 | Location 2 (repeated??) | struct |
 + | POBA | OnBegin Marker | null |
 + | INAM | OnBegin Idle | formid | FormID of an [IDLE](IDLE.md) record, or null.
-+ | | [OnBegin Embedded Script](Subrecords/Script.md) | collection | 
++ | | [OnBegin Embedded Script](Subrecords/Script.md) | collection |
 + | TNAM | OnBegin Topic | formid | FormID of a [DIAL](DIAL.md) record, or null.
 + | POBA | OnEnd Marker | null |
 + | INAM | OnEnd Idle | formid | FormID of an [IDLE](IDLE.md) record, or null.
-+ | | [OnEnd Embedded Script](Subrecords/Script.md) | collection | 
++ | | [OnEnd Embedded Script](Subrecords/Script.md) | collection |
 + | TNAM | OnEnd Topic | formid | FormID of a [DIAL](DIAL.md) record, or null.
 + | POBA | OnChange Marker | null |
 + | INAM | OnChange Idle | formid | FormID of an [IDLE](IDLE.md) record, or null.
-+ | | [OnChange Embedded Script](Subrecords/Script.md) | collection | 
++ | | [OnChange Embedded Script](Subrecords/Script.md) | collection |
 + | TNAM | OnChange Topic | formid | FormID of a [DIAL](DIAL.md) record, or null.
- 
+
 
 ### PKDT
 
@@ -133,7 +133,7 @@ The `Follow`, `Sleep`, `Travel`, `Accompany`, `Flee Not Combat`, `??`, `Patrol`,
 
 Value | Meaning (Find / Escort / Eat) | Meaning (Wander / Sandbox) | Meaning (Use Item At) | Meaning (Ambush) | Meaning (Guard)
 ------|-------------------------------|------------------|-----------------------|------------------|---------------
-0x0001 | ?? | No Eating | | Hide While Ambushing | 
+0x0001 | ?? | No Eating | | Hide While Ambushing |
 0x0002 | ?? | No Sleeping | Sit Down | |
 0x0004 | ?? | No Conversation | | | Remain Near Reference to Guard
 0x0008 | ?? | No Idle Markers | | |
@@ -141,9 +141,9 @@ Value | Meaning (Find / Escort / Eat) | Meaning (Wander / Sandbox) | Meaning (Us
 0x0020 | ?? | No Wandering | | |
 0x0040 | ?? | | | |
 0x0080 | ?? | | | |
-0x0100 | Allow Buying | | Allow Buying | 
-0x0200 | Allow Killing | | Allow Killing | 
-0x0400 | Allow Stealing | | Allow Stealing | 
+0x0100 | Allow Buying | | Allow Buying |
+0x0200 | Allow Killing | | Allow Killing |
+0x0400 | Allow Stealing | | Allow Stealing |
 
 ### Location Subrecord Collection
 
@@ -151,7 +151,7 @@ Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | PLDT | Location 1 | struct |
  | PLD2 | Location 2 | struct |
- 
+
 #### PLDT / PLD2
 
 Name | Type | Info
@@ -159,7 +159,7 @@ Name | Type | Info
 Type | uint32 | Enum - see below for values.
 Location | formid *or* uint32 *or* uint8[] | See below for data type info.
 Radius | int32 |
- 
+
 ##### Type Values & Location Data Types
 
 Type Value | Meaning | Location Data Type Info
@@ -274,7 +274,7 @@ Name | Type | Info
 -----|------|-----
 Repeatable | uint8 | A value of `0` means `Not Repeatable`, and a value of `1` means `Repeatable`.
 Unused | byte |
- 
+
 ### PKW3
 
 Name | Type | Info
@@ -288,7 +288,7 @@ Shots Per Volley (Max) | uint16 |
 Pause Between Volleys (Min) | float32 |
 Pause Between Volleys (Max) | float32 |
 Unused | byte[4] |
- 
+
 #### Flag Values
 
 Value | Meaning
@@ -342,7 +342,7 @@ Topic | formid | FormID of a [DIAL](DIAL.md) record, or null.
 Flags | uint32 | See below for values.
 Unused | byte[4] |
 Dialog Type | uint32 | Enum - see below for values.
- 
+
 #### Flag Values
 
 Value | Meaning
@@ -363,5 +363,3 @@ Value | Meaning
 ------|--------
 0 | Say Tosation
 1 | Say To
-
-

--- a/Fallout3/Records/RACE.md
+++ b/Fallout3/Records/RACE.md
@@ -15,9 +15,9 @@ Count | Subrecord | Name | Type | Info
  | ONAM | Older | formid | FormID of a [RACE](RACE.md) record.
  | YNAM | Younger | formid | FormID of a [RACE](RACE.md) record.
 + | NAM2 | Unkonwin Marker | null |
-+* | VTCK | Voice | formid | FormID of a [VTYP](VTYP.md) record. The first and second instances of this subrecord are for male and female voices respectively.
-+* | DNAM | Default Hair Style | formid | FormID of a [HAIR](HAIR.md) record. The first and second instances of this subrecord are for male and female hairs respectively.
-+* | CNAM | Default Hair Color | uint8 | Enum - see below for values. The first and second instances of this subrecord are for male and female hairs respectively.
++ | VTCK | Voices | struct |
++ | DNAM | Default Hair Styles | struct |
++ | CNAM | Default Hair Colors | struct |
 + | PNAM | FaceGen - Main Clamp | float32 |
 + | UNAM | FaceGen - Face Clamp | float32 |
 + | ATTR | Unknown | ?? |
@@ -31,8 +31,8 @@ Count | Subrecord | Name | Type | Info
 +* | | Male Body Part | collection | See below for details.
 + | FNAM | Female Body Data Marker | null |
 +* | | Female Body Part | collection | See below for details.
-+* | HNAM | Hair | formid | FormID of a [HAIR](HAIR.md) record.
-+* | ENAM | Eye | formid | FormID of an [EYES](EYES.md) record.
++ | HNAM | Hairs | formid[] | Array of [HAIR](HAIR.md) record FormIDs.
++ | ENAM | Eyes | formid[] | Array of [EYES](EYES.md) record FormIDs.
 + | MNAM | Male FaceGen Data Marker | null |
 + | FGGS | Male FaceGen Geometry-Symmetric | uint8[] |
 + | FGGA | Male FaceGen Geometry-Asymmetric | uint8[] |
@@ -79,7 +79,28 @@ Value | Meaning
 0x00000002 | ??
 0x00000004 | Child
 
-### Default Hair Color Values
+### VTCK
+
+Name | Type | Info
+-----|------|-----
+Male Voice | FormID of a [VTYP](VTYP.md) record.
+Female Voice | FormID of a [VTYP](VTYP.md) record.
+
+### DNAM
+
+Name | Type | Info
+-----|------|-----
+Male Default Hair Style | FormID of a [HAIR](HAIR.md) record, or null.
+Female Default Hair Style | FormID of a [HAIR](HAIR.md) record, or null.
+
+### CNAM
+
+Name | Type | Info
+-----|------|-----
+Male Default Hair Color | uint8 | Enum - see below for values.
+Female Default Hair Color | uint8 | Enum - see below for values.
+
+#### Default Hair Color Values
 
 Value | Meaning
 ------|--------

--- a/Fallout3/Records/REFR.md
+++ b/Fallout3/Records/REFR.md
@@ -55,14 +55,14 @@ Count | Subrecord | Name | Type | Info
  | ONAM | Open By Default | null |
  | XIBS | Ignored By Sandbox | null |
  | XNDP | Navigation Door Link | struct |
--* | XPOD | Portal Room | formid | FormID of a [REFR](REFR.md) record, or null.
+ | XPOD | Portal Rooms | formid[] | Array of [REFR](REFR.md) record FormIDs, or null.
  | XPLT | Portal Data | struct |
  | XSED | SpeedTree Seed | uint8 |
  | XRMR | Room Data Header | struct |
  | XLRM | Linked Room | formid | FormID of a [REFR](REFR.md) record.
  | XOCP | Occlusion Plane Data | struct |
--* | XORD | Linked Occlusion Plane | formid | FormID of a [REFR](REFR.md) record, or null. Each XORD subrecord corresponds to a different plane - the mapping is given below.
--* | XLOD | Distant LOD Data | byte[4] |
+ | XORD | Linked Occlusion Planes | struct |
+ | XLOD | Distant LOD Data | byte[12] | Unknown
  | XSCL | Scale | float32 |
  | [DATA](Subrecords/DATA (ACHR, ACRE).md) | Position / Rotation | struct |
 
@@ -273,11 +273,11 @@ Name | Type | Info
 Linked Rooms Count | uint16 |
 Unknown | byte[2] |
 
-### XORD Mapping
+### XORD
 
-Index | Occlusion Plane
-------|----------------
-0 | Right
-1 | Left
-2 | Bottom
-3 | Top
+Name | Type | Info
+-----|------|-----
+Right | formid | FormID of a [REFR](REFR.md) record, or null.
+Left | formid | FormID of a [REFR](REFR.md) record, or null.
+Bottom | formid | FormID of a [REFR](REFR.md) record, or null.
+Top | formid | FormID of a [REFR](REFR.md) record, or null.

--- a/Fallout3/Records/REGN.md
+++ b/Fallout3/Records/REGN.md
@@ -20,7 +20,7 @@ Count | Subrecord | Name | Type | Info
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | RPLI | Edge Fall-Off | uint32 |
--* | RPLD | Region Point List Data | struct |
+- | RPLD | Region Point List Data | struct |
 
 #### RPLD
 
@@ -34,13 +34,13 @@ Y | float32 |
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
 + | RDAT | Data Header | struct |
--* | RDOT | Object | struct |
+- | RDOT | Objects | struct |
  | RDMP | Map Name | cstring |
--* | RDGS | Grass | struct |
+- | RDGS | Grasses | struct |
  | RDMD | Music Type | uint32 | Enum - see below for values.
  | RDMO | Music | formid | FormID of a [MUSC](MUSC.md) record.
--* | RDSD | Sound | struct |
--* | RDWT | Weather Type | struct |
+- | RDSD | Sound | struct |
+- | RDWT | Weather Type | struct |
 
 #### RDAT
 
@@ -49,7 +49,7 @@ Name | Type | Info
 Type | uint32 | Enum - see below for values.
 Flags | uint8 | See below for values.
 Unused | byte |
- 
+
 ##### Type Values
 
 Value | Meaning
@@ -73,6 +73,8 @@ Value | Meaning
 
 #### RDOT
 
+The RDOT subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 Object | formid | FormID of a [TREE](TREE.md), [STAT](STAT.md) or [LTEX](LTEX.md) record.
@@ -94,7 +96,7 @@ X Angle Variance | uint16 |
 Y Angle Variance | uint16 |
 Z Angle Variance | uint16 |
 Unknown | byte[6] |
- 
+
 ##### Flag Values
 
 Value | Meaning
@@ -110,11 +112,13 @@ Value | Meaning
 
 #### RDGS
 
+The RDGS subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 Grass | formid | FormID of a [GRAS](GRAS.md) record.
 Unknown | byte[4] |
- 
+
 #### RDMD Values
 
 Value | Meaning
@@ -125,12 +129,14 @@ Value | Meaning
 
 #### RDSD
 
+The RDSD subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 Sound | formid | FormID of a [SOUN](SOUN.md) record.
 Flags | uint32 | See below for values.
 Chance | uint32 |
- 
+
 ##### Flag Values
 
 Value | Meaning
@@ -141,6 +147,8 @@ Value | Meaning
 0x00000008 | Snowy
 
 #### RDWT
+
+The RDWT subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----

--- a/Fallout3/Records/RGDL.md
+++ b/Fallout3/Records/RGDL.md
@@ -13,7 +13,7 @@ Count | Subrecord | Name | Type | Info
 + | XNAM | Actor Base | formid | FormID of a CREA ([FO3](../../Fallout3/Records/CREA.md), [FNV](../../FalloutNV/Records/CREA.md)) or NPC_ ([FO3](../../Fallout3/Records/NPC_.md), [FNV](../../FalloutNV/Records/NPC_.md)) record.
 + | TNAM | Body Part Data | formid | FormID of a [BPTD](BPTD.md) BPTD ([FO3](../../Fallout3/Records/BPTD.md), [FNV](../../FalloutNV/Records/BPTD.md)) record.
  | RAFD | Feedback Data | struct |
--* | RAFB | Feedback Dynamic Bone | uint16 |
+ | RAFB | Feedback Dynamic Bones | uint16[] |
 + | RAPS | Pose Matching Data | struct |
  | ANAM | Death Pose | cstring |
 

--- a/Fallout3/Records/SCOL.md
+++ b/Fallout3/Records/SCOL.md
@@ -17,9 +17,11 @@ Count | Subrecord | Name | Type | Info
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | ONAM | Static | formid | FormID of a [STAT](STAT.md) record.
-+* | DATA | Placement | struct |
++ | DATA | Placements | struct |
 
 #### DATA
+
+The DATA subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----

--- a/Fallout3/Records/SOUN.md
+++ b/Fallout3/Records/SOUN.md
@@ -11,7 +11,7 @@ Count | Subrecord | Name | Type | Info
 + | [OBND](Subrecords/OBND.md) | Object Bounds | struct |
  | FNAM | Sound Filename | cstring |
 + | SNDD *or* SNDX | Sound Data | struct |
--* | ANAM | Attenuation Point | int16 | There are 5 ANAM subrecords, each for a separate point on an attenuation curve.
+- | ANAM | Attenuation Points | int16[5] | Each int16 represents a separate point on an attenuation curve.
  | GNAM | Reverb Attenuation Control | int16 |
  | HNAM | Priority | int32 |
 

--- a/Fallout3/Records/Subrecords/IDLA.md
+++ b/Fallout3/Records/Subrecords/IDLA.md
@@ -1,0 +1,12 @@
+IDLA Subrecord
+==============
+
+Animations
+
+As used in the [PACK](../PACK.md) and [IDLM](../IDLM.md) record types.
+
+### Format
+
+Name | Type | Info
+-----|------|-----
+Idle Animations | formid[] | An array of [IDLE](IDLE.md) record FormIDs, or null.

--- a/Fallout3/Records/Subrecords/IMPF.md
+++ b/Fallout3/Records/Subrecords/IMPF.md
@@ -1,0 +1,23 @@
+IMPF Subrecord
+==============
+
+Footstep Material
+
+As used in the [WRLD](../WRLD.md) and [CELL](../CELL.md) record types.
+
+### Format
+
+The format of each field is unknown.
+
+Name | Type | Info
+-----|------|-----
+ConcSolid | byte[30] |
+ConcBroken | byte[30] |
+MetalSolid | byte[30] |
+MetalHollow | byte[30] |
+MetalSheet | byte[30] |
+Wood | byte[30] |
+Sand | byte[30] |
+Dirt | byte[30] |
+Grass | byte[30] |
+Water | byte[30] |

--- a/Fallout3/Records/TES4.md
+++ b/Fallout3/Records/TES4.md
@@ -11,7 +11,7 @@ Count | Subrecord | Name | Type | Info
 + | CNAM | author | cstring | Maximum size is 512 bytes, including terminator.
 - | SNAM | description | cstring | Maximum size is 512 bytes, including terminator.
 -* | | Master Data | | Data on the plugin's master files, listed in the order they were present in when the plugin was written.
-- | ONAM | formOverrides | formid[] | Overriden records. Number of records can be obtained by dividing the subrecord size by the size of a FormID.
+- | ONAM | formOverrides | formid[] | Overridden records. An array of [REFR](REFR.md), [ACHR](ACHR.md), [ACRE](ACRE.md), [PMIS](PMIS.md), [PBEA](PBEA.md), [PGRE](PGRE.md), [LAND](LAND.md) and [NAVM](NAVM.md) records.
 - | SCRN | screenshot | ?? | ??
 
 ### HEDR

--- a/Fallout3/Records/TREE.md
+++ b/Fallout3/Records/TREE.md
@@ -10,9 +10,9 @@ Count | Subrecord | Name | Type | Info
 + | EDID | Editor ID | cstring | Editor ID
 + | [OBND](Subrecords/OBND.md) | Object Bounds | struct |
 + | | [Model Data](Subrecords/Model.md) | collection |
-+ | ICON | Large icon filename | cstring | 
++ | ICON | Large icon filename | cstring |
 + | MICO | Small icon filename | cstring | 
-+* | SNAM | SpeedTree Seed | uint32 |
++ | SNAM | SpeedTree Seed | uint32[] |
 + | CNAM | Tree Data | struct |
 + | BNAM | Billboard Dimensions | struct |
 

--- a/Fallout3/Records/WRLD.md
+++ b/Fallout3/Records/WRLD.md
@@ -11,7 +11,7 @@ Count | Subrecord | Name | Type | Info
  | FULL | Name | cstring |
  | XEZN | Encounter Zone | formid | FormID of an [ECZN](ECZN.md) record.
  | WNAM | Parent Worldspace | formid | FormID of a [WRLD](WRLD.md) record.
-+ | PNAM | Parent Worldspace Flags | uint16 | See values below.
++ | PNAM | Parent Worldspace Flags | struct |
  | CNAM | Climate | formid | FormID of a [CLMT](CLMT.md) record.
  | NAM2 | Water | formid | FormID of a [WATR](WATR.md) record.
  | NAM3 | LOD Water Type | formid | FormID of a [WATR](WATR.md) record.
@@ -29,19 +29,28 @@ Count | Subrecord | Name | Type | Info
 + | NNAM | Canopy Shadow | cstring |
 + | XNAM | Water Noise Texture | cstring |
 -* | IMPS | Swapped Impact | struct |
--* | IMPF | Footstep Material | byte[30] | The format of each IMPF subrecord is unknown. There can be up to 10 IMPF subrecords, corresponding to different materials. The mapping is given below.
--* | OFST | Offset | uint32 |
+ | [IMPF](Subrecords/IMPF.md) | Footstep Material | struct |
+- | OFST | Offset | uint32[] |
 
-#### PNAM Values
+### PNAM
+
+Name | Type | Info
+-----|------|-----
+Flags | uint8 | See values below.
+Unknown | byte |
+
+#### Flag Values
 
 Value | Meaning
 ------|--------
-0x0001 | Use Land Data
-0x0002 | Use LOD Data
-0x0004 | Use Map Data
-0x0008 | Use Water Data
-0x0010 | Use Climate Data
-0x0020 | Use Image Space Data
+0x01 | Use Land Data
+0x02 | Use LOD Data
+0x04 | Use Map Data
+0x08 | Use Water Data
+0x10 | Use Climate Data
+0x20 | Use Image Space Data
+0x40 | ??
+0x80 | Needs Water Adjustment
 
 ### DNAM
 
@@ -96,18 +105,3 @@ Name | Type | Info
 [Material Type](Values/Impact Material Types.md) | uint32 |
 Old | formid | FormID of an [IPCT](IPCT.md) record.
 New | formid | FormID of an [IPCT](IPCT.md) record, or null.
-
-### IMPF Map
-
-IMPF Subrecord | Footstep Material
------------|------------------
-1st | ConcSolid
-2nd | ConcBroken
-3rd | MetalSolid
-4th | MetalHollow
-5th | MetalSheet
-6th | Wood
-7th | Sand
-8th | Dirt
-9th | Grass
-10th | Water

--- a/Fallout3/Records/WTHR.md
+++ b/Fallout3/Records/WTHR.md
@@ -20,15 +20,15 @@ Count | Subrecord | Name | Type | Info
 + | BNAM | Cloud Textures - Layer 3 | cstring |
  | | [Model Data](Subrecords/Model.md) | collection |
 + | LNAM | Unknown | byte[4] |
-+* | ONAM | Cloud Layer Speed | uint8 | Value is divided by 2550. There are 4 ONAMs, each for a different cloud layer.
--* | PNAM | Cloud Layer Color | struct | There are 4 PNAMs, each for a different cloud layer.
-+* | NAM0 | Colors by Time & Type | struct | There are 10 NAM0s. The mapping to types is given below.
++ | ONAM | Cloud Layer Speed | uint8[4] | Value is divided by 2550. Each uint8 is for a different cloud layer.
+- | PNAM | Cloud Layer Color | struct[4] | Array of Time of Day Colors structures. Each structure is for a different cloud layer.
++ | NAM0 | Colors by Time & Type | struct |
 + | FNAM | Fog Distance | struct |
 + | INAM | Unused | byte[304] |
 + | DATA | | struct |
 -* | SNAM | Sound | struct |
 
-### PNAM / NAM0
+### Time of Day Colors Structure
 
 Name | Type | Info
 -----|------|-----
@@ -37,20 +37,20 @@ Day | rgba |
 Sunset | rgba |
 Night | rgba |
 
-### NAM0 Mapping
+### NAM0
 
-NAM0 Index | Type
------------|-----
-0 | Sky-Upper
-1 | Fog
-2 | Unused
-3 | Ambient
-4 | Sunlight
-5 | Sun
-6 | Stars
-7 | Sky-Lower
-8 | Horizon
-9 | Unused
+Name | Type | Info
+-----|------|-----
+Sky-Upper | struct | A Time of Day Colors structure.
+Fog | struct | A Time of Day Colors structure.
+Unused | struct | A Time of Day Colors structure.
+Ambient | struct | A Time of Day Colors structure.
+Sunlight | struct | A Time of Day Colors structure.
+Sun | struct | A Time of Day Colors structure.
+Stars | struct | A Time of Day Colors structure.
+Sky-Lower | struct | A Time of Day Colors structure.
+Horizon | struct | A Time of Day Colors structure.
+Unused | struct | A Time of Day Colors structure.
 
 ### FNAM
 

--- a/FalloutNV/Records/CELL.md
+++ b/FalloutNV/Records/CELL.md
@@ -12,11 +12,11 @@ Count | Subrecord | Name | Type | Info
 + | DATA | Flags | uint8 | See below for values.
  | XCLC | Grid | struct |
  | XCLL | Lighting | struct |
--* | IMPF | Footstep Material | byte[30] | The format of each IMPF subrecord is unknown. There can be up to 10 IMPF subrecords, corresponding to different materials. The mapping is given below.
+ | [IMPF](Subrecords/IMPF.md) | Footstep Material | struct |
 + | | Light Template | collection | See below for details.
  | XCLW | Water Height | float32
  | XNAM | Water Noise Texture | cstring |
-*- | XCLR | Region | formid | FormID of a [REGN](REGN.md) record.
+ | XCLR | Regions | formid[] | Array of [REGN](REGN.md) record FormIDs.
  | XCIM | Image Space | formid | FormID of an [IMGS](IMGS.md) record.
  | XCET | Unknown | byte |
  | XEZN | Encounter Zone | formid | FormID of an [ECZN](ECZN.md) record.
@@ -41,22 +41,6 @@ Value | Meaning
 0x20 | Public Place
 0x40 | Hand Changed
 0x80 | Behave Like Exterior
-
-### IMPF Map
-
-IMPF Subrecord | Footstep Material
------------|------------------
-1st | ConcSolid
-2nd | ConcBroken
-3rd | MetalSolid
-4th | MetalHollow
-5th | MetalSheet
-6th | Wood
-7th | Sand
-8th | Dirt
-9th | Grass
-10th | Water
-
 
 ### XCLC
 
@@ -110,4 +94,3 @@ Value | Meaning
 0x00000040 | Directional Fade
 0x00000080 | Fog Clip Distance
 0x00000100 | Fog Power
-

--- a/FalloutNV/Records/CLMT.md
+++ b/FalloutNV/Records/CLMT.md
@@ -8,7 +8,7 @@ Climate
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
 + | EDID | Editor ID | cstring |
--* | WLST | Weather Type | struct | 
+- | WLST | Weather Types | struct |
  | FNAM | Sun Texture | cstring |
  | GNAM | Sun Glare Texture | cstring |
 - | | [Model Data](Subrecords/Model.md) | collection |
@@ -17,21 +17,21 @@ Count | Subrecord | Name | Type | Info
 
 ### WLST
 
+The WLST subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 Weather | formid | FormID of a [WTHR](WTHR.md) record, or null.
-Chance | int32 | 
+Chance | int32 |
 Global | formid | FormID of a [GLOB](GLOB.md) record, or null.
 
 ### TNAM
 
 Name | Type | Info
 -----|------|-----
-Sunrise Begin | uint8 | 
+Sunrise Begin | uint8 |
 Sunrise End | uint8 |
 Sunset Begin | uint8 |
 Sunset End | uint8 |
 Volatility | uint8 |
 Moons / Phase Length | uint8 |
- 
-

--- a/FalloutNV/Records/CPTH.md
+++ b/FalloutNV/Records/CPTH.md
@@ -9,9 +9,16 @@ Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
 + | EDID | Editor ID | cstring |
 -* | [CTDA](Subrecords/CTDA.md) | Condition | struct |
-+* | ANAM | Related Camera Path | formid | FormID of a [CPTH](CPTH.md) record, or null. The first ANAM subrecord maps to the parent, the second maps to the previous sibling.
+ | ANAM | Related Camera Paths | struct |
 + | DATA | Camera Zoom | uint8 | Enum - see below for values.
 -* | SNAM | Camera Shot | formid | FormID of a [CAMS](CAMS.md) record.
+
+### ANAM
+
+Name | Type | Info
+-----|------|-----
+Parent Camera Path | formid | FormID of a [CPTH](CPTH.md) record, or null.
+Previous Sibling Camera Path | formid | FormID of a [CPTH](CPTH.md) record, or null.
 
 ### DATA Enum Values
 

--- a/FalloutNV/Records/CREA.md
+++ b/FalloutNV/Records/CREA.md
@@ -14,7 +14,7 @@ Count | Subrecord | Name | Type | Info
 -* | SPLO | Actor Effect | formid | FormID of a [SPEL](SPEL.md) record.
  | EITM | Unarmed Attack Effect | formid | FormID of a [ENCH](ENCH.md) or [SPEL](SPEL.md) record.
 + | [EAMT](Values/Attack Animations.md) | Unarmed Attack Animation | uint16 |
--* | NIFZ | Model | cstring |
+- | NIFZ | Model List | cstring[] | An array of models.
  | NIFT | Texture File Hashes | uint8[] |
 + | [ACBS](Subrecords/ACBS.md) | Configuration | struct |
 -* | [SNAM](Subrecords/SNAM (CREA, NPC_).md) | Faction | struct |
@@ -26,7 +26,7 @@ Count | Subrecord | Name | Type | Info
 -* | | [Item](Subrecords/Item.md) | collection |
  | [AIDT](Subrecords/AIDT.md) | AI Data | struct |
 -* | PKID | Package | formid | FormID of a [PACK](PACK.md) record.
--* | KFFZ | Animation | cstring |
+- | KFFZ | Animations | cstring[] | An array of animations.
 + | DATA | Data | struct |
 + | RNAM | Attack Reach | uint8 |
  | ZNAM | Combat Style | formid | FormID of a [CSTY](CSTY.md) record.
@@ -109,4 +109,3 @@ Value | Meaning
 19 | Auxiliary 8
 20 | Jump
 21 | Play Random / Loop
-

--- a/FalloutNV/Records/DOBJ.md
+++ b/FalloutNV/Records/DOBJ.md
@@ -8,43 +8,43 @@ Default Object Manager
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
 + | EDID | Editor ID | cstring |
-+* | DATA | Default Object | formid | Each DATA subrecord is mapped to a different type of object. The mapping is given below.
++ | DATA | Default Objects | struct |
 
-### DATA Mapping
+### DATA
 
-DATA Subrecord Index | Object Type
------------------|------------
-0 | Stimpack
-1 | SuperStimpack
-2 | RadX
-3 | RadAway
-4 | Morphine
-5 | Perk Paralysis
-6 | Player Faction
-7 | Mysterious Stranger NPC
-8 | Mysterious Stranger Faction
-9 | Default Music
-10 | Battle Music
-11 | Death Music
-12 | Success Music
-13 | Level Up Music
-14 | Player Voice (Male)
-15 | Player Voice (Male Child)
-16 | Player Voice (Female)
-17 | Player Voice (Female Child)
-18 | Eat Package Default Food
-19 | Every Actor Ability
-20 | Drug Wears Off Image Space
-21 | Doctor's Bag
-22 | Miss Fortune NPC
-23 | Miss Fortune Faction
-24 | Meltdown Explosion
-25 | Unarmed Forward PA
-26 | Unarmed Backward PA
-27 | Unarmed Left PA
-28 | Unarmed Right PA
-29 | Unarmed Crouch PA
-30 | Unarmed Counter PA
-31 | Spotter Effect
-32 | Item Detected Efect
-33 | Cateye Mobile Effect (NYI)
+Name | Type | Info
+-----|------|-----
+Stimpack | formid |
+SuperStimpack | formid |
+RadX | formid |
+RadAway | formid |
+Morphine | formid |
+Perk Paralysis | formid |
+Player Faction | formid |
+Mysterious Stranger NPC | formid |
+Mysterious Stranger Faction | formid |
+Default Music | formid |
+Battle Music | formid |
+Death Music | formid |
+Success Music | formid |
+Level Up Music | formid |
+Player Voice (Male) | formid |
+Player Voice (Male Child) | formid |
+Player Voice (Female) | formid |
+Player Voice (Female Child) | formid |
+Eat Package Default Food | formid |
+Every Actor Ability | formid |
+Drug Wears Off Image Space | formid |
+Doctor's Bag | formid |
+Miss Fortune NPC | formid |
+Miss Fortune Faction | formid |
+Meltdown Explosion | formid |
+Unarmed Forward PA | formid |
+Unarmed Backward PA | formid |
+Unarmed Left PA | formid |
+Unarmed Right PA | formid |
+Unarmed Crouch PA | formid |
+Unarmed Counter PA | formid |
+Spotter Effect | formid |
+Item Detected Efect | formid |
+Cateye Mobile Effect (NYI) | formid |

--- a/FalloutNV/Records/IDLE.md
+++ b/FalloutNV/Records/IDLE.md
@@ -10,8 +10,15 @@ Count | Subrecord | Name | Type | Info
  | EDID | Editor ID | cstring |
 + | | [Model Data](Subrecords/Model.md) | collection |
 -* | [CTDA](Subrecords/CTDA.md) | Condition | struct |
-+* | ANAM | Related Idle Animation | formid | FormID of an [IDLE](IDLE.md) record, or null. The first ANAM subrecord is for the parent, the second for the previous sibling.
+ | ANAM | Related Idle Animations | struct |
 + | DATA | | struct |
+
+### ANAM
+
+Name | Type | Info
+-----|------|-----
+Parent Idle Animation | formid | FormID of a [IDLE](IDLE.md) record, or null.
+Previous Sibling Idle Animation | formid | FormID of a [IDLE](IDLE.md) record, or null.
 
 ### DATA
 
@@ -24,7 +31,7 @@ Unused | byte |
 Replay Delay | int16 |
 Flags | uint8 | See below for values.
 Unused | byte |
- 
+
 #### Animation Group Section Values
 
 Value | Animation Group

--- a/FalloutNV/Records/IDLM.md
+++ b/FalloutNV/Records/IDLM.md
@@ -10,9 +10,9 @@ Count | Subrecord | Name | Type | Info
 + | EDID | Editor ID | cstring |
 + | [OBND](Subrecords/OBND.md) | Object Bounds | struct |
 + | IDLF | Flags | uint8 | See below for values.
-+ | IDLC | | struct | 
++ | IDLC | | struct |
 + | IDLT | Idle Timer Setting | float32 |
-+* | IDLA | Animation | formid | FormID of a [IDLE](IDLE.md) record, or null.
+ | [IDLA](Subrecords/IDLA.md) | Animations | struct |
 
 ### IDLF Flag Values
 
@@ -28,4 +28,3 @@ Name | Type | Info
 -----|------|-----
 Animation Count | uint8 |
 Unused | byte[3] |
- 

--- a/FalloutNV/Records/IMAD.md
+++ b/FalloutNV/Records/IMAD.md
@@ -1,45 +1,45 @@
 IMAD
 ====
 
-Image Space Modifier
+Image Space Adapter
 
 ## Format
 
-Some of the subrecord codes begin with unprintable or whitespace characters. Such characters are given below using their hex values. Eg. `IIAD` would be `0x49 IAD` below if `I` were unprintable.
+Some of the subrecord codes begin with unprintable or whitespace characters. Such characters are given below using their hex values. Eg. `IIAD` would be `0x49 IAD` below if `I` were unprintable. The Time and Color structures used by many of the subrecords are detailed below.
 
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | EDID | Editor ID | cstring |
- | DNAM | Unknown | ?? |
- | BNAM | Unknown | ?? |
- | VNAM | Unknown | ?? |
- | TNAM | Unknown | ?? |
- | NAM3 | Unknown | ?? |
- | RNAM | Unknown | ?? |
- | SNAM | Unknown | ?? |
- | UNAM | Unknown | ?? |
- | NAM1 | Unknown | ?? |
- | NAM2 | Unknown | ?? |
- | WNAM | Unknown | ?? |
- | XNAM | Unknown | ?? |
- | YNAM | Unknown | ?? |
- | NAM4 | Unknown | ?? |
- | 0x00 IAD | Unknown | ?? |
- | @IAD | Unknown | ?? |
- | 0x01 IAD | Unknown | ?? |
- | AIAD | Unknown | ?? |
- | 0x02 IAD | Unknown | ?? |
- | BIAD | Unknown | ?? |
- | 0x03 IAD | Unknown | ?? |
- | CIAD | Unknown | ?? |
- | 0x04 IAD | Unknown | ?? |
- | DIAD | Unknown | ?? |
- | 0x05 IAD | Unknown | ?? |
- | EIAD | Unknown | ?? |
- | 0x06 IAD | Unknown | ?? |
- | FIAD | Unknown | ?? |
- | 0x07 IAD | Unknown | ?? |
- | GIAD | Unknown | ?? |
+ | DNAM | Data Count | struct |
+ | BNAM | Blur Radius | struct[] | An array of Time structures.
+ | VNAM | Double Vision Strength | struct[] | An array of Time structures.
+ | TNAM | Tint Color | struct[] | An array of Color structures.
+ | NAM3 | Fade Color | struct[] | An array of Color structures.
+ | RNAM | Radial Blur Strength | struct[] | An array of Time structures.
+ | SNAM | Radial Blur Ramp Up | struct[] | An array of Time structures.
+ | UNAM | Radial Blur Start | struct[] | An array of Time structures.
+ | NAM1 | Radial Blur Ramp Down | struct[] | An array of Time structures.
+ | NAM2 | Radial Blur Down Start | struct[] | An array of Time structures.
+ | WNAM | DoF Strength | struct[] | An array of Time structures.
+ | XNAM | DoF Distance | struct[] | An array of Time structures.
+ | YNAM | DoF Range | struct[] | An array of Time structures.
+ | NAM4 | Motion Blur Strength | struct[] | An array of Time structures.
+ | 0x00 IAD | HDR Eye Adapt Speed Mult | struct[] | An array of Time structures.
+ | @IAD | HDR Eye Adapt Speed Add | struct[] | An array of Time structures.
+ | 0x01 IAD | HDR Bloom Blur Radius Mult | struct[] | An array of Time structures.
+ | AIAD | HDR Bloom Blur Radius Add | struct[] | An array of Time structures.
+ | 0x02 IAD | HDR Bloom Threshold Mult | struct[] | An array of Time structures.
+ | BIAD | HDR Bloom Threshold Add | struct[] | An array of Time structures.
+ | 0x03 IAD | HDR Bloom Scale Mult | struct[] | An array of Time structures.
+ | CIAD | HDR Bloom Scale Add | struct[] | An array of Time structures.
+ | 0x04 IAD | HDR Target Lum Min Mult | struct[] | An array of Time structures.
+ | DIAD | HDR Target Lum Min Add | struct[] | An array of Time structures.
+ | 0x05 IAD | HDR Target Lum Max Mult | struct[] | An array of Time structures.
+ | EIAD | HDR Target Lum Max Add | struct[] | An array of Time structures.
+ | 0x06 IAD | HDR Sunlight Scale Mult | struct[] | An array of Time structures.
+ | FIAD | HDR Sunlight Scale Add | struct[] | An array of Time structures.
+ | 0x07 IAD | HDR Sky Scale Mult | struct[] | An array of Time structures.
+ | GIAD | HDR Sky Scale Add | struct[] | An array of Time structures.
  | 0x08 IAD | Unknown | ?? |
  | HIAD | Unknown | ?? |
  | 0x09 IAD | Unknown | ?? |
@@ -58,14 +58,97 @@ Count | Subrecord | Name | Type | Info
  | OIAD | Unknown | ?? |
  | 0x10 IAD | Unknown | ?? |
  | PIAD | Unknown | ?? |
- | 0x11 IAD | Unknown | ?? |
- | QIAD | Unknown | ?? |
- | 0x12 IAD | Unknown | ?? |
- | RIAD | Unknown | ?? |
- | 0x13 IAD | Unknown | ?? |
- | SIAD | Unknown | ?? |
+ | 0x11 IAD | Cinematic Saturation Mult | struct[] | An array of Time structures.
+ | QIAD | Cinematic Saturation Add | struct[] | An array of Time structures.
+ | 0x12 IAD | Cinematic Brightness Mult | struct[] | An array of Time structures.
+ | RIAD | Cinematic Brightness Add | struct[] | An array of Time structures.
+ | 0x13 IAD | Cinematic Contrast Mult | struct[] | An array of Time structures.
+ | SIAD | Cinematic Contrast Add | struct[] | An array of Time structures.
  | 0x14 IAD | Unknown | ?? |
  | TIAD | Unknown | ?? |
  | RDSD | Sound - Intro | formid | FormID of a [SOUN](SOUN.md) record.
  | RDSI | Sound - Outro | formid | FormID of a [SOUN](SOUN.md) record.
 
+
+### DNAM
+
+Name | Type | Info
+-----|------|-----
+Flags | uint32 | See below for flag values.
+Duration | float32 |
+HDR Eye Adapt Speed Mult | uint32 |
+HDR Eye Adapt Speed Add | uint32 |
+HDR Bloom Blur Radius Mult | uint32 |
+HDR Bloom Blur Radius Add | uint32 |
+HDR Bloom Threshold Mult | uint32 |
+HDR Bloom Threshold Add | uint32 |
+HDR Bloom Scale Mult | uint32 |
+HDR Bloom Scale Add | uint32 |
+HDR Target Lum Min Mult | uint32 |
+HDR Target Lum Min Add | uint32 |
+HDR Target Lum Max Mult | uint32 |
+HDR Target Lum Max Add | uint32 |
+HDR Sunlight Scale Mult | uint32 |
+HDR Sunlight Scale Add | uint32 |
+HDR Sky Scale Mult | uint32 |
+HDR Sky Scale Add | uint32 |
+Unknown | uint8[72] |
+Cinematic Saturation Mult | uint32 |
+Cinematic Saturation Add | uint32 |
+Cinematic Brightness Mult | uint32 |
+Cinematic Brightness Add | uint32 |
+Cinematic Contrast Mult | uint32 |
+Cinematic Contrast Add | uint32 |
+Unknown | uint8[8] |
+Tint Color | uint32 |
+Blur Radius | uint32 |
+Double Vision Strength | uint32 |
+Radial Blur Strength | uint32 |
+Radial Blur Ramp Up | uint32 |
+Radial Blur Start | uint32 |
+Radial Blur Flags | uint32 | See below for flag values.
+Radial Blur Center X | uint32 |
+Radial Blur Center Y | uint32 |
+Depth of Field Strength | uint32 |
+Depth of Field Distance | uint32 |
+Depth of Field Range | uint32 |
+Depth of Field Flags | uint32 | See below for flag values.
+Radial Blur Ramp Down | uint32 |
+Radial Blur Down Start | uint32 |
+Fade Color | uint32 |
+Motion Blur Strength | uint32 |
+
+#### Flag Values
+
+Value | Meaning
+------|--------
+0x00000001 | Animatable
+
+#### Radial Blur Flag Values
+
+Value | Meaning
+------|--------
+0x00000001 | Use Target
+
+#### Depth of Field Flag Values
+
+Value | Meaning
+------|--------
+0x00000001 | Use Target
+
+### Time Structure
+
+Name | Type | Info
+-----|------|-----
+Time | float32 |
+Value | float32 |
+
+### Color Structure
+
+Name | Type | Info
+-----|------|-----
+Time | float32 |
+Red | float32 |
+Green | float32 |
+Blue | float32 |
+Alpha | float32 |

--- a/FalloutNV/Records/LAND.md
+++ b/FalloutNV/Records/LAND.md
@@ -8,15 +8,15 @@ Landscape
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | DATA | Unknown | uint8[] |
--* | VNML | Vertex Normal | struct | There are 33 VNML structs.
+ | VNML | Vertex Normals | struct |
  | VHGT | Vertex Height Map | struct |
--* | VCLR | Vertex Color |
+ | VCLR | Vertex Colors | struct |
 -* | | Layer Subrecord Collection | collection | See below for details.
--* | VTEX | Texture | formid | FormID of an [LTEX](LTEX.md) record, or null.
+ | VTEX | Textures | formid[] | An array of [LTEX](LTEX.md) record FormIDs, or null.
 
 ### VNML / VCLR
 
-Each VNML / VCLR structure contains 33 repeats of the following structure, so that the array of VNML / VCLR structs forms a 33x33 grid where each VNML / VCLR is a row, and each instance of the structure below is a column.
+Each VNML / VCLR structure contains 1089 repeats of the following structure. The 1089 repeats are divided into 33 rows, and subdivided into 33 columns, forming a 33x33 grid.
 
 Name | Type | Info
 -----|------|-----
@@ -65,13 +65,14 @@ Value | Meaning
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | ATXT | Alpha Layer Header | struct |
--* | VTXT | Alpha Layer Cell Data | struct |
+ | VTXT | Alpha Layer Cell Data | struct |
 
 ##### VTXT
+
+The VTXT subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----
 Position | uint16 |
 Unused | byte[2] |
 Opacity | float32 |
-

--- a/FalloutNV/Records/NAVM.md
+++ b/FalloutNV/Records/NAVM.md
@@ -10,12 +10,12 @@ Count | Subrecord | Name | Type | Info
  | EDID | Editor ID | cstring |
  | NVER | Version | uint32 |
  | DATA | Data | struct |
--* | NVVX | Vertex | struct |
--* | NVTR | Triangle | struct |
--* | NVCA | Triangle | int16 |
--* | NVDP | Door | struct |
+ | NVVX | Vertices | struct |
+ | NVTR | Triangles | struct |
+ | NVCA | Unknown | int16[] | Unknown, may be triangle IDs.
+ | NVDP | Doors | struct |
  | NVGD | NavMesh Grid | struct |
--* | NVEX | External Connection | struct |
+ | NVEX | External Connections | struct |
 
 ### DATA
 
@@ -30,6 +30,8 @@ Doors Count | uint32 |
 
 ### NVVX
 
+The NVVX subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 X | float32 |
@@ -37,6 +39,8 @@ Y | float32 |
 Z | float32 |
 
 ### NVTR
+
+The NVTR subrecord consists of an array of objects with the following structure.
 
 Count | Name | Type | Info
 ------|------|------|-----
@@ -87,6 +91,8 @@ Value | Meaning
 
 ### NVDP
 
+The NVDP subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 Reference | formid | FormID of a [REFR](REFR.md) record.
@@ -115,6 +121,8 @@ Count | Name | Type | Info
 -* | Triangle | int16 |
 
 ### NVEX
+
+The NVEX subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----

--- a/FalloutNV/Records/PACK.md
+++ b/FalloutNV/Records/PACK.md
@@ -16,7 +16,7 @@ Count | Subrecord | Name | Type | Info
 + | IDLF | Idle Animation Flags | uint8 | See below for values.
 + | IDLC | Idle Animation Count | struct |
 + | IDLT | Idle Timer Setting | float32 |
-+* | IDLA | Idle Animations | formid | FormID of an [IDLE](IDLE.md) record.
+ | [IDLA](Subrecords/IDLA.md) | Animations | struct |
  | IDLB | Unused | byte[4] |
  | CNAM | Combat Style | formid | FormID of a [CSTY](CSTY.md) record.
  | PKED | Eat Marker | null |
@@ -363,5 +363,3 @@ Value | Meaning
 ------|--------
 0 | Say Tosation
 1 | Say To
-
-

--- a/FalloutNV/Records/RACE.md
+++ b/FalloutNV/Records/RACE.md
@@ -15,9 +15,9 @@ Count | Subrecord | Name | Type | Info
  | ONAM | Older | formid | FormID of a [RACE](RACE.md) record.
  | YNAM | Younger | formid | FormID of a [RACE](RACE.md) record.
 + | NAM2 | Unkonwin Marker | null |
-+* | VTCK | Voice | formid | FormID of a [VTYP](VTYP.md) record. The first and second instances of this subrecord are for male and female voices respectively.
-+* | DNAM | Default Hair Style | formid | FormID of a [HAIR](HAIR.md) record, or null. The first and second instances of this subrecord are for male and female hairs respectively.
-+* | DNAM | Default Hair Color | uint8 | Enum - see below for values. The first and second instances of this subrecord are for male and female hairs respectively.
++ | VTCK | Voices | struct |
++ | DNAM | Default Hair Styles | struct |
++ | CNAM | Default Hair Colors | struct |
 + | PNAM | FaceGen - Main Clamp | float32 |
 + | UNAM | FaceGen - Face Clamp | float32 |
 + | ATTR | Unknown | ?? |
@@ -31,8 +31,8 @@ Count | Subrecord | Name | Type | Info
 +* | | Male Body Part | collection | See below for details.
 + | FNAM | Female Body Data Marker | null |
 +* | | Female Body Part | collection | See below for details.
-+* | HNAM | Hair | formid | FormID of a [HAIR](HAIR.md) record.
-+* | ENAM | Eye | formid | FormID of an [EYES](EYES.md) record.
++ | HNAM | Hairs | formid[] | Array of [HAIR](HAIR.md) record FormIDs.
++ | ENAM | Eyes | formid[] | Array of [EYES](EYES.md) record FormIDs.
 + | MNAM | Male FaceGen Data Marker | null |
 + | FGGS | Male FaceGen Geometry-Symmetric | uint8[] |
 + | FGGA | Male FaceGen Geometry-Asymmetric | uint8[] |
@@ -79,7 +79,28 @@ Value | Meaning
 0x00000002 | ??
 0x00000004 | Child
 
-### Default Hair Color Values
+### VTCK
+
+Name | Type | Info
+-----|------|-----
+Male Voice | FormID of a [VTYP](VTYP.md) record.
+Female Voice | FormID of a [VTYP](VTYP.md) record.
+
+### DNAM
+
+Name | Type | Info
+-----|------|-----
+Male Default Hair Style | FormID of a [HAIR](HAIR.md) record, or null.
+Female Default Hair Style | FormID of a [HAIR](HAIR.md) record, or null.
+
+### CNAM
+
+Name | Type | Info
+-----|------|-----
+Male Default Hair Color | uint8 | Enum - see below for values.
+Female Default Hair Color | uint8 | Enum - see below for values.
+
+#### Default Hair Color Values
 
 Value | Meaning
 ------|--------

--- a/FalloutNV/Records/REFR.md
+++ b/FalloutNV/Records/REFR.md
@@ -65,14 +65,14 @@ Count | Subrecord | Name | Type | Info
  | ONAM | Open By Default | null |
  | XIBS | Ignored By Sandbox | null |
  | XNDP | Navigation Door Link | struct |
--* | XPOD | Portal Room | formid | FormID of a [REFR](REFR.md) record, or null.
+ | XPOD | Portal Rooms | formid[] | Array of [REFR](REFR.md) record FormIDs, or null.
  | XPLT | Portal Data | struct |
  | XSED | SpeedTree Seed | uint8 |
  | XRMR | Room Data Header | struct |
  | XLRM | Linked Room | formid | FormID of a [REFR](REFR.md) record.
  | XOCP | Occlusion Plane Data | struct |
--* | XORD | Linked Occlusion Plane | formid | FormID of a [REFR](REFR.md) record, or null. Each XORD subrecord corresponds to a different plane - the mapping is given below.
--* | XLOD | Distant LOD Data | byte[4] |
+ | XORD | Linked Occlusion Planes | struct |
+ | XLOD | Distant LOD Data | byte[12] | Unknown
  | XSCL | Scale | float32 |
  | [DATA](Subrecords/DATA (ACHR, ACRE).md) | Position / Rotation | struct |
 
@@ -283,11 +283,11 @@ Name | Type | Info
 Linked Rooms Count | uint16 |
 Unknown | byte[2] |
 
-### XORD Mapping
+### XORD
 
-Index | Occlusion Plane
-------|----------------
-0 | Right
-1 | Left
-2 | Bottom
-3 | Top
+Name | Type | Info
+-----|------|-----
+Right | formid | FormID of a [REFR](REFR.md) record, or null.
+Left | formid | FormID of a [REFR](REFR.md) record, or null.
+Bottom | formid | FormID of a [REFR](REFR.md) record, or null.
+Top | formid | FormID of a [REFR](REFR.md) record, or null.

--- a/FalloutNV/Records/REGN.md
+++ b/FalloutNV/Records/REGN.md
@@ -20,9 +20,11 @@ Count | Subrecord | Name | Type | Info
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | RPLI | Edge Fall-Off | uint32 |
--* | RPLD | Region Point List Data | struct |
+- | RPLD | Region Point List Data | struct |
 
 #### RPLD
+
+The RPLD subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----
@@ -34,16 +36,16 @@ Y | float32 |
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
 + | RDAT | Data Header | struct |
--* | RDOT | Object | struct |
+- | RDOT | Objects | struct |
  | RDMP | Map Name | cstring |
--* | RDGS | Grass | struct |
+- | RDGS | Grasses | struct |
  | RDMD | Music Type | uint32 | Enum - see below for values.
  | RDMO | Music | formid | FormID of a [MUSC](MUSC.md) record.
  | RDSI | Incidental MediaSet | formid | FormID of an [MSET](MSET.md) record.
 -* | RDSB | Battle MediaSet | formid | FormID of an [MSET](MSET.md) record.
--* | RDSD | Sound | struct |
--* | RDWT | Weather Type | struct |
--* | RDID | Imposter | formid | FormID of a [REFR](REFR.md) record.
+- | RDSD | Sounds | struct |
+- | RDWT | Weather Types | struct |
+- | RDID | Imposters | formid[] | An array of [REFR](REFR.md) record FormIDs.
 
 #### RDAT
 
@@ -75,6 +77,8 @@ Value | Meaning
 0x01 | Override
 
 #### RDOT
+
+The RDOT subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----
@@ -113,6 +117,8 @@ Value | Meaning
 
 #### RDGS
 
+The RDGS subrecord consists of an array of objects with the following structure.
+
 Name | Type | Info
 -----|------|-----
 Grass | formid | FormID of a [GRAS](GRAS.md) record.
@@ -127,6 +133,8 @@ Value | Meaning
 2 | Dungeon
 
 #### RDSD
+
+The RDSD subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----
@@ -144,6 +152,8 @@ Value | Meaning
 0x00000008 | Snowy
 
 #### RDWT
+
+The RDWT subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----

--- a/FalloutNV/Records/RGDL.md
+++ b/FalloutNV/Records/RGDL.md
@@ -13,7 +13,7 @@ Count | Subrecord | Name | Type | Info
 + | XNAM | Actor Base | formid | FormID of a CREA ([FO3](../../Fallout3/Records/CREA.md), [FNV](../../FalloutNV/Records/CREA.md)) or NPC_ ([FO3](../../Fallout3/Records/NPC_.md), [FNV](../../FalloutNV/Records/NPC_.md)) record.
 + | TNAM | Body Part Data | formid | FormID of a [BPTD](BPTD.md) BPTD ([FO3](../../Fallout3/Records/BPTD.md), [FNV](../../FalloutNV/Records/BPTD.md)) record.
  | RAFD | Feedback Data | struct |
--* | RAFB | Feedback Dynamic Bone | uint16 |
+ | RAFB | Feedback Dynamic Bones | uint16[] |
 + | RAPS | Pose Matching Data | struct |
  | ANAM | Death Pose | cstring |
 

--- a/FalloutNV/Records/SCOL.md
+++ b/FalloutNV/Records/SCOL.md
@@ -17,9 +17,11 @@ Count | Subrecord | Name | Type | Info
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | ONAM | Static | formid | FormID of a [STAT](STAT.md) record.
-+* | DATA | Placement | struct |
++ | DATA | Placements | struct |
 
 #### DATA
+
+The DATA subrecord consists of an array of objects with the following structure.
 
 Name | Type | Info
 -----|------|-----

--- a/FalloutNV/Records/SOUN.md
+++ b/FalloutNV/Records/SOUN.md
@@ -12,7 +12,7 @@ Count | Subrecord | Name | Type | Info
  | FNAM | Sound Filename | cstring |
  | RNAM | Random Chance % | uint8 |
 + | SNDD *or* SNDX | Sound Data | struct |
--* | ANAM | Attenuation Point | int16 | There are 5 ANAM subrecords, each for a separate point on an attenuation curve.
+ | ANAM | Attenuation Points | int16[5] | Each int16 represents a separate point on an attenuation curve.
  | GNAM | Reverb Attenuation Control | int16 |
  | HNAM | Priority | int32 |
 

--- a/FalloutNV/Records/Subrecords/IDLA.md
+++ b/FalloutNV/Records/Subrecords/IDLA.md
@@ -1,0 +1,12 @@
+IDLA Subrecord
+==============
+
+Animations
+
+As used in the [PACK](../PACK.md) and [IDLM](../IDLM.md) record types.
+
+### Format
+
+Name | Type | Info
+-----|------|-----
+Idle Animations | formid[] | An array of [IDLE](IDLE.md) record FormIDs, or null.

--- a/FalloutNV/Records/Subrecords/IMPF.md
+++ b/FalloutNV/Records/Subrecords/IMPF.md
@@ -1,0 +1,23 @@
+IMPF Subrecord
+==============
+
+Footstep Material
+
+As used in the [WRLD](../WRLD.md) and [CELL](../CELL.md) record types.
+
+### Format
+
+The format of each field is unknown.
+
+Name | Type | Info
+-----|------|-----
+ConcSolid | byte[30] |
+ConcBroken | byte[30] |
+MetalSolid | byte[30] |
+MetalHollow | byte[30] |
+MetalSheet | byte[30] |
+Wood | byte[30] |
+Sand | byte[30] |
+Dirt | byte[30] |
+Grass | byte[30] |
+Water | byte[30] |

--- a/FalloutNV/Records/TES4.md
+++ b/FalloutNV/Records/TES4.md
@@ -11,7 +11,7 @@ Count | Subrecord | Name | Type | Info
 + | CNAM | author | cstring | Maximum size is 512 bytes, including terminator.
 - | SNAM | description | cstring | Maximum size is 512 bytes, including terminator.
 -* | | Master Data | | Data on the plugin's master files, listed in the order they were present in when the plugin was written.
-- | ONAM | formOverrides | formid[] | Overriden records. Number of records can be obtained by dividing the subrecord size by the size of a FormID.
+- | ONAM | formOverrides | formid[] | Overridden records. An array of [REFR](REFR.md), [ACHR](ACHR.md), [ACRE](ACRE.md), [PMIS](PMIS.md), [PBEA](PBEA.md), [PGRE](PGRE.md), [LAND](LAND.md) and [NAVM](NAVM.md) records.
 - | SCRN | screenshot | ?? | ??
 
 ### HEDR

--- a/FalloutNV/Records/TREE.md
+++ b/FalloutNV/Records/TREE.md
@@ -10,9 +10,9 @@ Count | Subrecord | Name | Type | Info
 + | EDID | Editor ID | cstring | Editor ID
 + | [OBND](Subrecords/OBND.md) | Object Bounds | struct |
 + | | [Model Data](Subrecords/Model.md) | collection |
-+ | ICON | Large icon filename | cstring | 
-+ | MICO | Small icon filename | cstring | 
-+* | SNAM | SpeedTree Seed | uint32 |
++ | ICON | Large icon filename | cstring |
++ | MICO | Small icon filename | cstring |
++ | SNAM | SpeedTree Seeds | uint32[] |
 + | CNAM | Tree Data | struct |
 + | BNAM | Billboard Dimensions | struct |
 

--- a/FalloutNV/Records/WRLD.md
+++ b/FalloutNV/Records/WRLD.md
@@ -11,7 +11,7 @@ Count | Subrecord | Name | Type | Info
  | FULL | Name | cstring |
  | XEZN | Encounter Zone | formid | FormID of an [ECZN](ECZN.md) record.
  | WNAM | Parent Worldspace | formid | FormID of a [WRLD](WRLD.md) record.
-+ | PNAM | Parent Worldspace Flags | struct |
++ | PNAM | Parent Worldspace Flags | uint16 | See values below.
  | CNAM | Climate | formid | FormID of a [CLMT](CLMT.md) record.
  | NAM2 | Water | formid | FormID of a [WATR](WATR.md) record.
  | NAM3 | LOD Water Type | formid | FormID of a [WATR](WATR.md) record.
@@ -29,28 +29,19 @@ Count | Subrecord | Name | Type | Info
 + | NNAM | Canopy Shadow | cstring |
 + | XNAM | Water Noise Texture | cstring |
 -* | IMPS | Swapped Impact | struct |
--* | IMPF | Footstep Material | byte[30] | The format of each IMPF subrecord is unknown. There can be up to 10 IMPF subrecords, corresponding to different materials. The mapping is given below.
--* | OFST | Offset | uint32 |
+ | [IMPF](Subrecords/IMPF.md) | Footstep Material | struct |
+- | OFST | Offset Data | uint32[] |
 
-### PNAM
-
-Name | Type | Info
------|------|-----
-Flags | uint8 | See values below.
-Unknown | byte |
- 
-#### Flag Values
+#### PNAM Values
 
 Value | Meaning
 ------|--------
-0x01 | Use Land Data
-0x02 | Use LOD Data
-0x04 | Use Map Data
-0x08 | Use Water Data
-0x10 | Use Climate Data
-0x20 | Use Image Space Data
-0x40 | ??
-0x80 | Needs Water Adjustment
+0x0001 | Use Land Data
+0x0002 | Use LOD Data
+0x0004 | Use Map Data
+0x0008 | Use Water Data
+0x0010 | Use Climate Data
+0x0020 | Use Image Space Data
 
 ### DNAM
 
@@ -58,7 +49,7 @@ Name | Type | Info
 -----|------|-----
 Default Land Height | float32 |
 Default Water Height | float32 |
- 
+
 ### MNAM
 
 Name | Type | Info
@@ -69,7 +60,7 @@ NW Cell X Coordinate | int16 |
 NW Cell Y Coordinate | int16 |
 SE Cell X Coordinate | int16 |
 SE Cell Y Coordinate | int16 |
- 
+
 ### ONAM
 
 Name | Type | Info
@@ -77,7 +68,7 @@ Name | Type | Info
 World Map Scale | float32 |
 Cell X Offset | float32 |
 Cell Y Offset | float32 |
- 
+
 ### DATA Values
 
 Value | Meaning
@@ -105,18 +96,3 @@ Name | Type | Info
 [Material Type](Values/Impact Material Types.md) | uint32 |
 Old | formid | FormID of an [IPCT](IPCT.md) record.
 New | formid | FormID of an [IPCT](IPCT.md) record, or null.
-
-### IMPF Map
-
-IMPF Subrecord | Footstep Material
------------|------------------
-1st | ConcSolid
-2nd | ConcBroken
-3rd | MetalSolid
-4th | MetalHollow
-5th | MetalSheet
-6th | Wood
-7th | Sand
-8th | Dirt
-9th | Grass
-10th | Water

--- a/FalloutNV/Records/WTHR.md
+++ b/FalloutNV/Records/WTHR.md
@@ -22,15 +22,15 @@ Count | Subrecord | Name | Type | Info
 + | BNAM | Cloud Textures - Layer 3 | cstring |
  | | [Model Data](Subrecords/Model.md) | collection |
 + | LNAM | Unknown | byte[4] |
-+* | ONAM | Cloud Layer Speed | uint8 | Value is divided by 2550. There are 4 ONAMs, each for a different cloud layer.
--* | PNAM | Cloud Layer Color | struct | There are 4 PNAMs, each for a different cloud layer.
-+* | NAM0 | Colors by Time & Type | struct | There are 10 NAM0s. The mapping to types is given below.
++ | ONAM | Cloud Layer Speed | uint8[4] | Value is divided by 2550. Each uint8 is for a different cloud layer.
+- | PNAM | Cloud Layer Color | struct[4] | Array of Time of Day Colors structures. Each structure is for a different cloud layer.
++ | NAM0 | Colors by Time & Type | struct |
 + | FNAM | Fog Distance | struct |
 + | INAM | Unused | byte[304] |
 + | DATA | | struct |
 -* | SNAM | Sound | struct |
 
-### PNAM / NAM0
+### Time of Day Colors Structure
 
 Name | Type | Info
 -----|------|-----
@@ -41,20 +41,20 @@ Night | rgba |
 High Noon | rgba |
 Midnight | rgba |
 
-### NAM0 Mapping
+### NAM0
 
-NAM0 Index | Type
------------|-----
-0 | Sky-Upper
-1 | Fog
-2 | Unused
-3 | Ambient
-4 | Sunlight
-5 | Sun
-6 | Stars
-7 | Sky-Lower
-8 | Horizon
-9 | Unused
+Name | Type | Info
+-----|------|-----
+Sky-Upper | struct | A Time of Day Colors structure.
+Fog | struct | A Time of Day Colors structure.
+Unused | struct | A Time of Day Colors structure.
+Ambient | struct | A Time of Day Colors structure.
+Sunlight | struct | A Time of Day Colors structure.
+Sun | struct | A Time of Day Colors structure.
+Stars | struct | A Time of Day Colors structure.
+Sky-Lower | struct | A Time of Day Colors structure.
+Horizon | struct | A Time of Day Colors structure.
+Unused | struct | A Time of Day Colors structure.
 
 ### FNAM
 


### PR DESCRIPTION
These commits together fix #19 for FO3 and FNV. In addition:

* IMAD has been updated with the fields that have been decoded since it was written.
* The WRLD definition files were named WLRD.md, this typo has been corrected.
* The ONAM subrecord in TES4 has had its allowed record types listed.