### PR TITLE
FNV: Typo corrections and table fixes

### DIFF
--- a/Fallout3/Records.md
+++ b/Fallout3/Records.md
@@ -60,7 +60,7 @@ Type | Name
 [IPDS](Records/IPDS.md) | Impact Data Set
 [KEYM](Records/KEYM.md) | Key
 [LAND](Records/LAND.md) | Landscape
-[LGMT](Records/LGMT.md) | Lighting Template
+[LGTM](Records/LGTM.md) | Lighting Template
 [LIGH](Records/LIGH.md) | Light
 [LSCR](Records/LSCR.md) | Load Screen
 [LTEX](Records/LTEX.md) | Landscape Texture

--- a/Fallout3/Records/LIGH.md
+++ b/Fallout3/Records/LIGH.md
@@ -28,7 +28,7 @@ Name | Type | Info
 ------|------|------|-----
 Time | int32 |
 Radius | uint32 |
-Color | rbga |
+Color | rgba |
 Flags | uint32 | See below for values.
 Falloff Exponent | float32 |
 FOV | float32 |

--- a/Fallout3/Records/PERK.md
+++ b/Fallout3/Records/PERK.md
@@ -42,7 +42,7 @@ Value | Meaning
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | PRKE | Header | struct |
-+ | DATA | Effect Data | struct *or * formid |
++ | DATA | Effect Data | struct *or* formid |
 -* | | Perk Conditions | collection | See below for details.
  | EPFT | Entry Point Function Type | uint8 | Decides the data type of the EPFD record.
  | EPFD | Entry Point Function Data | uint8[] *or* float32 *or* formid *or* null |

--- a/Fallout3/Records/Subrecords/Model.md
+++ b/Fallout3/Records/Subrecords/Model.md
@@ -34,7 +34,7 @@ Count | Name | Type | Info
 + | Count | uint32 | Number of alternate textures.
 -* | Alternate Texture | struct | A sub-subrecord structure detailed below.
 
-#### Aternate Texture
+#### Alternate Texture
 
 Name | Type | Info
 -----|------|-----

--- a/Fallout4/Records/Subrecords/Model.md
+++ b/Fallout4/Records/Subrecords/Model.md
@@ -34,7 +34,7 @@ Count | Name | Type | Info
 + | Count | uint32 | Number of alternate textures.
 -* | Alternate Texture | struct | A sub-subrecord structure detailed below.
 
-#### Aternate Texture
+#### Alternate Texture
 
 Name | Type | Info
 -----|------|-----

--- a/FalloutNV/Records.md
+++ b/FalloutNV/Records.md
@@ -71,7 +71,7 @@ Type | Name
 [IPDS](Records/IPDS.md) | Impact Data Set
 [KEYM](Records/KEYM.md) | Key
 [LAND](Records/LAND.md) | Landscape
-[LGMT](Records/LGMT.md) | Lighting Template
+[LGTM](Records/LGTM.md) | Lighting Template
 [LIGH](Records/LIGH.md) | Light
 [LSCR](Records/LSCR.md) | Load Screen
 [LSCT](Records/LSCT.md) | Load Screen Type

--- a/FalloutNV/Records/BPTD.md
+++ b/FalloutNV/Records/BPTD.md
@@ -55,12 +55,12 @@ To Hit Chance | uint8 |
 Explodable - Explosion Chance % | uint8 |
 Explodable - Debris Count | uint16 |
 Explodable - Debris | formid | FormID of a [DEBR](DEBR.md) record, or null.
-Explodable - Explosion | FormID of a [EXPL](EXPL.md) record, or null.
+Explodable - Explosion | formid | FormID of a [EXPL](EXPL.md) record, or null.
 Tracking Max Angle | float32 |
 Explodable - Debris Scale | float32 |
 Severable - Debris Count | int32 |
 Severable - Debris | formid | FormID of a [DEBR](DEBR.md) record, or null.
-Severable - Explosion | FormID of a [EXPL](EXPL.md) record, or null.
+Severable - Explosion | formid | FormID of a [EXPL](EXPL.md) record, or null.
 Severable - Debris Scale | float32 |
 Gore Effects - Translate X | float32 |
 Gore Effects - Translate Y | float32 |

--- a/FalloutNV/Records/CELL.md
+++ b/FalloutNV/Records/CELL.md
@@ -18,7 +18,7 @@ Count | Subrecord | Name | Type | Info
  | XCLL | Lighting | struct |
  | [IMPF](Subrecords/IMPF.md) | Footstep Material | struct |
 + | | Light Template | collection | See below for details.
- | XCLW | Water Height | float32
+ | XCLW | Water Height | float32 |
  | XNAM | Water Noise Texture | cstring |
  | XCLR | Regions | formid[] | Array of [REGN](REGN.md) record FormIDs.
  | XCIM | Image Space | formid | FormID of an [IMGS](IMGS.md) record.

--- a/FalloutNV/Records/CHAL.md
+++ b/FalloutNV/Records/CHAL.md
@@ -18,8 +18,8 @@ Count | Subrecord | Name | Type | Info
  | SCRI | Script | formid | FormID of a [SCPT](SCPT.md) record.
  | DESC | Description | cstring |
  | DATA | Data | struct |
- | SNAM | Value3 | FormID | Depends on DATA.Type
- | XNAM | Value4 | FormID | Depends on Data.Type
+ | SNAM | Value3 | formid | Depends on Data.Type
+ | XNAM | Value4 | formid | Depends on Data.Type
 
 ### DATA
 

--- a/FalloutNV/Records/CHAL.md
+++ b/FalloutNV/Records/CHAL.md
@@ -35,8 +35,8 @@ Value3 | byte[4] | Depends on Type
 
 #### Type Values
 
-Value | Meaning |
-------|---------|
+Value | Meaning
+------|--------
 0 | Kill From A Form List
 1 | Kill A Specific FormID
 2 | Kill Any In A Category

--- a/FalloutNV/Records/CREA.md
+++ b/FalloutNV/Records/CREA.md
@@ -66,8 +66,8 @@ Luck | uint8 |
 
 #### Type Enum Values
 
-Values | Meaning
--------|--------
+Value | Meaning
+------|--------
 0 | Animal
 1 | Mutated Animal
 2 | Mutated Insect
@@ -79,13 +79,13 @@ Values | Meaning
 
 ### Sound Type Subrecord Collection
 
+CSDI and CSDC are in a repeated block.
+
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | CSDT | Type | uint32 | Enum - see below for values.
 +* | CSDI | Sound | formid | FormID of a [SOUN](SOUN.md) record, or null.
 +* | CSDC | Sound Chance | uint8 |
-
-CSDI and CSDC are in a repeated block.
 
 #### CSDT Enum Values
 

--- a/FalloutNV/Records/EFSH.md
+++ b/FalloutNV/Records/EFSH.md
@@ -15,7 +15,7 @@ Count | Subrecord | Name | Type | Info
  | ICON | Fill Texture | cstring |
  | ICO2 | Particle Shader Texture | cstring |
  | NAM7 | Holes Texture | cstring |
-+ | DATA | Data | struct
++ | DATA | Data | struct |
  
 ### DATA
 

--- a/FalloutNV/Records/EXPL.md
+++ b/FalloutNV/Records/EXPL.md
@@ -36,5 +36,5 @@ Sound 2 | formid | FormID of a [SOUN](SOUN.md) record, or null.
 Radiation Level | float32 |
 Radiation Dissipation Time | float32 |
 Radiation Radius | float32 |
-+ | [Sound Level](Values/Sound Levels.md) | uint32 | Enum - see link for values.
+[Sound Level](Values/Sound Levels.md) | uint32 | Enum - see link for values.
 

--- a/FalloutNV/Records/IMGS.md
+++ b/FalloutNV/Records/IMGS.md
@@ -16,6 +16,8 @@ Count | Subrecord | Name | Type | Info
 
 ### DNAM
 
+The `rgb` data types above are apparently float32 triplets, with the first being for red, the second for green and the third for blue.
+
 Name | Type | Info
 -----|------|-----
 HDR Eye Adapt Speed | float32 |
@@ -49,8 +51,6 @@ Cinmatic Brightness Tint Value | float32 |
 Unused | byte[16] |
 Flags | uint8 | See below for values.
 Unused | byte[3] |
- 
-The `rgb` data types above are apparently float32 triplets, with the first being for red, the second for green and the third for blue.
  
 #### Flag Values
 

--- a/FalloutNV/Records/LIGH.md
+++ b/FalloutNV/Records/LIGH.md
@@ -28,7 +28,7 @@ Name | Type | Info
 -----|------|-----
 Time | int32 |
 Radius | uint32 |
-Color | rbga |
+Color | rgba |
 Flags | uint32 | See below for values.
 Falloff Exponent | float32 |
 FOV | float32 |

--- a/FalloutNV/Records/LIGH.md
+++ b/FalloutNV/Records/LIGH.md
@@ -25,7 +25,7 @@ Count | Subrecord | Name | Type | Info
 ### DATA
 
 Name | Type | Info
-------|------|------|-----
+-----|------|-----
 Time | int32 |
 Radius | uint32 |
 Color | rbga |

--- a/FalloutNV/Records/LIGH.md
+++ b/FalloutNV/Records/LIGH.md
@@ -19,7 +19,7 @@ Count | Subrecord | Name | Type | Info
  | ICON | Large Icon Filename | cstring |
  | MICO | Small Icon FIlename | cstring |
 + | DATA | | struct |
-+ | FMAM | Fade Value | foat32 |
++ | FMAM | Fade Value | float32 |
  | SNAM | Sound | formid | FormID of a SOUN ([FO3](../../Fallout3/Records/SOUN.md), [FNV](../../FalloutNV/Records/SOUN.md)) record.
 
 ### DATA

--- a/FalloutNV/Records/MGEF.md
+++ b/FalloutNV/Records/MGEF.md
@@ -22,7 +22,7 @@ Count | Subrecord | Name | Type | Info
 ### DATA
 
 Name | Type | Info
-------|------|------|-----
+-----|------|-----
 Flags | uint32 | See below for values.
 Base Cost | float32 | Unused.
 Associated Item | formid |

--- a/FalloutNV/Records/PACK.md
+++ b/FalloutNV/Records/PACK.md
@@ -145,9 +145,9 @@ Value | Meaning (Find / Escort / Eat) | Meaning (Wander / Sandbox) | Meaning (Us
 0x0020 | ?? | No Wandering | | |
 0x0040 | ?? | | | |
 0x0080 | ?? | | | |
-0x0100 | Allow Buying | | Allow Buying |
-0x0200 | Allow Killing | | Allow Killing |
-0x0400 | Allow Stealing | | Allow Stealing |
+0x0100 | Allow Buying | | Allow Buying | |
+0x0200 | Allow Killing | | Allow Killing | |
+0x0400 | Allow Stealing | | Allow Stealing | |
 
 ### Location Subrecord Collection
 

--- a/FalloutNV/Records/PERK.md
+++ b/FalloutNV/Records/PERK.md
@@ -42,7 +42,7 @@ Value | Meaning
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
  | PRKE | Header | struct |
-+ | DATA | Effect Data | struct *or * formid |
++ | DATA | Effect Data | struct *or* formid |
 -* | | Perk Conditions | collection | See below for details.
  | EPFT | Entry Point Function Type | uint8 | Decides the data type of the EPFD record.
  | EPFD | Entry Point Function Data | uint8[] *or* float32 *or* formid *or* null |

--- a/FalloutNV/Records/PERK.md
+++ b/FalloutNV/Records/PERK.md
@@ -20,7 +20,7 @@ Count | Subrecord | Name | Type | Info
 + | DATA | Data | struct |
 -* | | Effect | collection | See below for details.
 
-### DATA (Data)
+### DATA
 
 Name | Type | Info
 -----|------|-----

--- a/FalloutNV/Records/PERK.md
+++ b/FalloutNV/Records/PERK.md
@@ -184,6 +184,8 @@ Count | Subrecord | Name | Type | Info
 
 The subrecord type is decided as described in the table below.
 
+If the EPFT value is `2` and DATA's Function field (when DATA is an entry point) is `5`, the EPFD type is chosen as if the EPFT value were `5`.
+
 EPFT Value | EPFD Type | Info
 -----------|-----------|-----
 0 | uint8[] |
@@ -192,8 +194,6 @@ EPFT Value | EPFD Type | Info
 3 | formid | FormID of a [LVLI](LVLI.md) record.
 4 | null |
 5 | struct | A struct consisting of a `uint32` [actor value](Values/Actor Values.md) enum followed by a `float32` value.
-
-If the EPFT value is `2` and DATA's Function field (when DATA is an entry point) is `5`, the EPFD type is chosen as if the EPFT value were `5`.
 
 #### EPF3 Flag Values
 

--- a/FalloutNV/Records/PROJ.md
+++ b/FalloutNV/Records/PROJ.md
@@ -16,7 +16,7 @@ Count | Subrecord | Name | Type | Info
  | FULL | Name | cstring |
 + | | [Model Data](Subrecords/Model.md) | collection |
  | | [Destruction Data](Subrecords/Destruction.md) | collection |
-+ | [DATA](#data) | Data | struct
++ | [DATA](#data) | Data | struct |
 + | NAM1 | Muzzle Flash Model Filename | cstring |
 + | NAM2 | Muzzle Flash Model Texture File Hashes | uint8[] |
 + | [VNAM](Values/Sound Levels.md) | Sound Level | uint32 | Enum - see link for values.

--- a/FalloutNV/Records/PWAT.md
+++ b/FalloutNV/Records/PWAT.md
@@ -14,7 +14,7 @@ Count | Subrecord | Name | Type | Info
 + | EDID | Editor ID | cstring |
 + | [OBND](Subrecords/OBND.md) | Object Bounds | struct |
 + | | [Model Data](Subrecords/Model.md) | collection |
-+ | DNAM | | struct
++ | DNAM | | struct |
  
 ### DNAM
 

--- a/FalloutNV/Records/QUST.md
+++ b/FalloutNV/Records/QUST.md
@@ -51,7 +51,7 @@ Count | Subrecord | Name | Type | Info
 
 Count | Subrecord | Name | Type | Info
 ------|-------|------|------|-----
- | Stage Flags | uint8 | See below for values.
+ | QSDT | Stage Flags | uint8 | See below for values.
 -* | CTDA | Condition | struct | [FO3](../../Fallout3/Records/Subrecords/CTDA.md) and [FNV](../../FalloutNV/Records/Subrecords/CTDA.md) definitions differ.
  | CNAM | Log Entry | cstring |
 + | | Embedded Script | collection | [FO3](../../Fallout3/Records/Subrecords/Script.md) and [FNV](../../FalloutNV/Records/Subrecords/Script.md) definitions differ.

--- a/FalloutNV/Records/RACE.md
+++ b/FalloutNV/Records/RACE.md
@@ -87,15 +87,15 @@ Value | Meaning
 
 Name | Type | Info
 -----|------|-----
-Male Voice | FormID of a [VTYP](VTYP.md) record.
-Female Voice | FormID of a [VTYP](VTYP.md) record.
+Male Voice | formid | FormID of a [VTYP](VTYP.md) record.
+Female Voice | formid | FormID of a [VTYP](VTYP.md) record.
 
 ### DNAM
 
 Name | Type | Info
 -----|------|-----
-Male Default Hair Style | FormID of a [HAIR](HAIR.md) record, or null.
-Female Default Hair Style | FormID of a [HAIR](HAIR.md) record, or null.
+Male Default Hair Style | formid | FormID of a [HAIR](HAIR.md) record, or null.
+Female Default Hair Style | formid | FormID of a [HAIR](HAIR.md) record, or null.
 
 ### CNAM
 

--- a/FalloutNV/Records/REFR.md
+++ b/FalloutNV/Records/REFR.md
@@ -228,7 +228,7 @@ Name | Type | Info
 Range Radius | float32 |
 Broadcast Range Type | uint32 | Enum - see below for values.
 Static Percentage | float32 |
-Position Reference | FormID of a [REFR](REFR.md), [ACRE](ACRE.md), [ACHR](ACHR.md), [PGRE](PGRE.md) or [PMIS](PMIS.md) record, or null.
+Position Reference | formid | FormID of a [REFR](REFR.md), [ACRE](ACRE.md), [ACHR](ACHR.md), [PGRE](PGRE.md) or [PMIS](PMIS.md) record, or null.
 
 #### Broadcast Range Type Values
 

--- a/FalloutNV/Records/REFR.md
+++ b/FalloutNV/Records/REFR.md
@@ -70,7 +70,7 @@ Count | Subrecord | Name | Type | Info
  | XIBS | Ignored By Sandbox | null |
  | XNDP | Navigation Door Link | struct |
  | XPOD | Portal Rooms | formid[] | Array of [REFR](REFR.md) record FormIDs, or null.
- | XPLT | Portal Data | struct |
+ | XPTL | Portal Data | struct |
  | XSED | SpeedTree Seed | uint8 |
  | XRMR | Room Data Header | struct |
  | XLRM | Linked Room | formid | FormID of a [REFR](REFR.md) record.

--- a/FalloutNV/Records/REGN.md
+++ b/FalloutNV/Records/REGN.md
@@ -17,7 +17,7 @@ Count | Subrecord | Name | Type | Info
 + | RCLR | Map Color | rgba |
  | WNAM | Worldspace | formid | FormID of a [WRLD](WRLD.md) record.
 -* | | Region Area | collection | See below for details.
--* | Region Data Entry | collection | See below for details.
+-* | | Region Data Entry | collection | See below for details.
 
 ### Region Area Subrecord Collection
 

--- a/FalloutNV/Records/Subrecords/ACBS.md
+++ b/FalloutNV/Records/Subrecords/ACBS.md
@@ -13,7 +13,7 @@ Name | Type | Info
 -----|------|-----
 Flags | uint32 | See below for values.
 Fatigue | uint16 |
-Barter Gold | uint16
+Barter Gold | uint16 |
 Level / Level Mult | int16 | If the 0x00000080 flag is set, the value is divided by 1000 to give a multiplier.
 Calc Min | uint16 |
 Calc Max | uint16 |

--- a/FalloutNV/Records/Subrecords/AIDT.md
+++ b/FalloutNV/Records/Subrecords/AIDT.md
@@ -7,7 +7,7 @@ AIDT Subrecord
 
 As used in the [CREA](../CREA.md) and [NPC_](../NPC_.md) record types.
 
-## Fomat
+## Format
 
 Name | Type | Info
 -----|------|-----

--- a/FalloutNV/Records/Subrecords/Model.md
+++ b/FalloutNV/Records/Subrecords/Model.md
@@ -34,7 +34,7 @@ Count | Name | Type | Info
 + | Count | uint32 | Number of alternate textures.
 -* | Alternate Texture | struct | A sub-subrecord structure detailed below.
 
-#### Aternate Texture
+#### Alternate Texture
 
 Name | Type | Info
 -----|------|-----

--- a/FalloutNV/Records/Subrecords/Script.md
+++ b/FalloutNV/Records/Subrecords/Script.md
@@ -2,7 +2,8 @@
 layout: falloutnvrec
 title: fopdoc
 ---
-# Script Subrecord Collection
+Script Subrecord Collection
+===========================
 
 ## Format
 

--- a/FalloutNV/Records/Subrecords/XNAM (FACT, RACE).md
+++ b/FalloutNV/Records/Subrecords/XNAM (FACT, RACE).md
@@ -7,6 +7,8 @@ XNAM Subrecord
 
 As used in the [FACT](../FACT.md) and [RACE](../RACE.md) record types.
 
+## Format
+
 Name | Type | Info
 -----|------|-----
 Faction | formid | FormID of a [FACT](../FACT.md) or [RACE](../RACE.md) record.

--- a/FalloutNV/Records/TES4.md
+++ b/FalloutNV/Records/TES4.md
@@ -14,7 +14,7 @@ Count | Subrecord | Name | Type | Info
 - | DELE | unknown | ?? | ??
 + | CNAM | author | cstring | Maximum size is 512 bytes, including terminator.
 - | SNAM | description | cstring | Maximum size is 512 bytes, including terminator.
--* | | Master Data | | Data on the plugin's master files, listed in the order they were present in when the plugin was written.
+-* | | Master Data | collection | Data on the plugin's master files, listed in the order they were present in when the plugin was written.
 - | ONAM | formOverrides | formid[] | Overridden records. An array of [REFR](REFR.md), [ACHR](ACHR.md), [ACRE](ACRE.md), [PMIS](PMIS.md), [PBEA](PBEA.md), [PGRE](PGRE.md), [LAND](LAND.md) and [NAVM](NAVM.md) records.
 - | SCRN | screenshot | ?? | ??
 

--- a/FalloutNV/Records/TES4.md
+++ b/FalloutNV/Records/TES4.md
@@ -5,6 +5,8 @@ title: fopdoc
 TES4 Record
 ===========
 
+Plugin Info
+
 ## Format
 
 Count | Subrecord | Name | Type | Info


### PR DESCRIPTION
1. The record list has "`LGMT`" record listed, which links to non-existing "`Records/LGMT.md`" file. This patch changes the entry to "`LGTM`", which does exist in game files and has a description in "`Records/LGTM.md`".
2. Change `FormID` into `formid` in `Records/CHAL.md` (types are lowercase)
3. Typo fix: `foat32` (should be `float32`) - `Records/LIGH.md`
4. Add missing table column into `Region Data Entry` row in `Records/REGN.md`
5. Add missing type (`collection`) into `Master Data` row in `Records/TES4.md`