### PR TITLE
(fo3/fnv): Add missing MODT subrecord definition (#17)

### DIFF
--- a/Fallout3/Records/DEBR.md
+++ b/Fallout3/Records/DEBR.md
@@ -2,26 +2,26 @@
 layout: fallout3rec
 title: fopdoc
 ---
-DEBR
-====
+DEBR Record
+===========
 
 Debris
 
 ## Format
 
 Count | Subrecord | Name | Type | Info
-------|-------|------|------|-----
+------|-----------|------|------|-----
 + | EDID | Editor ID | cstring |
 +* | | Debris Model | collection | See below for details.
 
 ### Debris Model Subrecord Collection
 
 Count | Subrecord | Name | Type | Info
-------|-------|------|------|-----
-+ | DATA | Data | struct |
-+ | MODT | Texture File Hashes | ?? |
+------|-----------|------|------|-----
++ | DATA | Data | struct | See below for details.
+- | [MODT](Subrecords/MODT.md) | Texture Filename Hashes | struct[] |
 
-#### DATA
+#### DATA Subrecord
 
 Name | Type | Info
 -----|------|-----

--- a/Fallout3/Records/Subrecords/MODT.md
+++ b/Fallout3/Records/Subrecords/MODT.md
@@ -1,0 +1,28 @@
+---
+layout: fallout3rec
+title: fopdoc
+---
+MODT Subrecord
+==============
+
+Texture Filename Hashes
+
+## Format
+
+Count | Name | Type | Info
+------|------|------|-----
++* | Texture Filename Hashes | struct |
+
+### Texture Filename Hashes
+
+Name | Type | Info
+-----|------|-----
+DDS Hash | byte[8] | DDS filename hash
+DDX Hash | byte[8] | DDX filename hash (XBox 360)
+DIR Hash | byte[8] | Directory hash
+
+### Notes
+
+May be used to map DDS filenames to XBox 360 DDX filenames. One entry for each texture referenced in the model.
+
+This is unverified as the GECK does not create this subrecord. However it is 'internally' consistent as each texture reference with the same path has the same directory hash value.

--- a/Fallout3/Records/Subrecords/Model.md
+++ b/Fallout3/Records/Subrecords/Model.md
@@ -3,7 +3,7 @@ layout: fallout3rec
 title: fopdoc
 ---
 Model Subrecord Collection
-======================
+==========================
 
 The MODL, MODB, MODT, MODS and MODD subrecords hold model data, and always appear together. In cases where multiple collections are present in the same record, the subrecord codes are numbered:
 
@@ -15,33 +15,33 @@ MODT | MO2T | MO3T | MO4T
 MODS | MO2S | MO3S | MO4S
 MODD | (always missing) | MOSD | (always missing)
 
-Whenever a model subrecord collection is referenced in these docs, assume it is the first instance unless a number is given. If so, substitute the appropriate subrecord codes below.
+Whenever a model subrecord collection is referenced in these docs, assume it is the first instance unless a number is given. If so, substitute the appropriate subrecord codes as shown above.
 
 ## Format
 
 Count | Subrecord | Name | Type | Info
-------|-------|------|------|-----
+------|-----------|------|------|-----
 + | MODL | Model Filename | cstring |
 - | MODB | Unknown | byte[4] |
-- | MODT | Texture File Hashes | ?? |
+- | [MODT](Subrecords/MODT.md) | Texture Filename Hashes | struct[] |
 - | MODS | Alternate Textures | struct | See below for details.
 - | MODD | FaceGen Model Flags | uint8 | See below for flag values.
 
-### MODS
+### MODS Subrecord
 
 Count | Name | Type | Info
 ------|------|------|-----
 + | Count | uint32 | Number of alternate textures.
--* | Alternate Texture | struct | A sub-subrecord structure detailed below.
+-* | Alternate Texture Data | struct | See below for details.
 
-#### Alternate Texture
+#### Alternate Texture Data
 
 Name | Type | Info
 -----|------|-----
-Name Length | uint32 | Alternate texture data. Length of the following 3D name.
-3D Name | char[Name Length] | Alternate texture data.
-New Texture | formid | Alternate texture data. FormID of a [TXST](../TXST.md) record.
-3D Index | int32 | Alternate texture data.
+Name Length | uint32 | Length of the following 3D name.
+3D Name | char[Name Length] |
+New Texture | formid | FormID of a [TXST](../TXST.md) record.
+3D Index | int32 |
 
 ### MODD Flag Values
 

--- a/FalloutNV/Records/DEBR.md
+++ b/FalloutNV/Records/DEBR.md
@@ -2,26 +2,26 @@
 layout: falloutnvrec
 title: fopdoc
 ---
-DEBR
-====
+DEBR Record
+===========
 
 Debris
 
 ## Format
 
 Count | Subrecord | Name | Type | Info
-------|-------|------|------|-----
+------|-----------|------|------|-----
 + | EDID | Editor ID | cstring |
 +* | | Debris Model | collection | See below for details.
 
 ### Debris Model Subrecord Collection
 
 Count | Subrecord | Name | Type | Info
-------|-------|------|------|-----
-+ | DATA | Data | struct |
-+ | MODT | Texture File Hashes | ?? |
+------|-----------|------|------|-----
++ | DATA | Data | struct | See below for details.
+- | [MODT](Subrecords/MODT.md) | Texture Filename Hashes | struct[] |
 
-#### DATA
+#### DATA Subrecord
 
 Name | Type | Info
 -----|------|-----

--- a/FalloutNV/Records/Subrecords/MODT.md
+++ b/FalloutNV/Records/Subrecords/MODT.md
@@ -1,0 +1,28 @@
+---
+layout: falloutnvrec
+title: fopdoc
+---
+MODT Subrecord
+==============
+
+Texture Filename Hashes
+
+## Format
+
+Count | Name | Type | Info
+------|------|------|-----
++* | Texture Filename Hashes | struct |
+
+### Texture Filename Hashes
+
+Name | Type | Info
+-----|------|-----
+DDS Hash | byte[8] | DDS filename hash
+DDX Hash | byte[8] | DDX filename hash (XBox 360)
+DIR Hash | byte[8] | Directory hash
+
+### Notes
+
+May be used to map DDS filenames to XBox 360 DDX filenames. One entry for each texture referenced in the model.
+
+This is unverified as the GECK does not create this subrecord. However it is 'internally' consistent as each texture reference with the same path has the same directory hash value.

--- a/FalloutNV/Records/Subrecords/Model.md
+++ b/FalloutNV/Records/Subrecords/Model.md
@@ -3,7 +3,7 @@ layout: falloutnvrec
 title: fopdoc
 ---
 Model Subrecord Collection
-======================
+==========================
 
 The MODL, MODB, MODT, MODS and MODD subrecords hold model data, and always appear together. In cases where multiple collections are present in the same record, the subrecord codes are numbered:
 
@@ -15,33 +15,33 @@ MODT | MO2T | MO3T | MO4T
 MODS | MO2S | MO3S | MO4S
 MODD | (always missing) | MOSD | (always missing)
 
-Whenever a model subrecord collection is referenced in these docs, assume it is the first instance unless a number is given. If so, substitute the appropriate subrecord codes below.
+Whenever a model subrecord collection is referenced in these docs, assume it is the first instance unless a number is given. If so, substitute the appropriate subrecord codes as shown above.
 
 ## Format
 
 Count | Subrecord | Name | Type | Info
-------|-------|------|------|-----
+------|-----------|------|------|-----
 + | MODL | Model Filename | cstring |
 - | MODB | Unknown | byte[4] |
-- | MODT | Texture File Hashes | ?? |
+- | [MODT](Subrecords/MODT.md) | Texture Filename Hashes | struct[] |
 - | MODS | Alternate Textures | struct | See below for details.
 - | MODD | FaceGen Model Flags | uint8 | See below for flag values.
 
-### MODS
+### MODS Subrecord
 
 Count | Name | Type | Info
 ------|------|------|-----
 + | Count | uint32 | Number of alternate textures.
--* | Alternate Texture | struct | A sub-subrecord structure detailed below.
+-* | Alternate Texture Data | struct | See below for details.
 
-#### Alternate Texture
+#### Alternate Texture Data
 
 Name | Type | Info
 -----|------|-----
-Name Length | uint32 | Alternate texture data. Length of the following 3D name.
-3D Name | char[Name Length] | Alternate texture data.
-New Texture | formid | Alternate texture data. FormID of a [TXST](../TXST.md) record.
-3D Index | int32 | Alternate texture data.
+Name Length | uint32 | Length of the following 3D name.
+3D Name | char[Name Length] |
+New Texture | formid | FormID of a [TXST](../TXST.md) record.
+3D Index | int32 |
 
 ### MODD Flag Values
 


### PR DESCRIPTION
 - Change DEBR/MODT count field to optional as GECK does not create
   MODT subrecords for new Debris forms.
 - Tidy 'Alternate Texture Data' info and clarify signature changes
   description for Model.md
 - Fix format inconsistancies.